### PR TITLE
Revert changes UTC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1884,7 +1884,7 @@ dependencies = [
 [[package]]
 name = "pragma-monitoring"
 version = "0.1.0"
-source = "git+https://github.com/astraly-labs/pragma-monitoring?rev=c475da8#c475da8fa2c49f9057f6c3dfa493f26c648f6d49"
+source = "git+https://github.com/akhercha/pragma-monitoring?branch=fix/revert_datetime_update#e9791babf85c1c67616ca1295992cc4180ff948e"
 dependencies = [
  "arc-swap",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1884,7 +1884,7 @@ dependencies = [
 [[package]]
 name = "pragma-monitoring"
 version = "0.1.0"
-source = "git+https://github.com/akhercha/pragma-monitoring?branch=fix/revert_datetime_update#e9791babf85c1c67616ca1295992cc4180ff948e"
+source = "git+https://github.com/astraly-labs/pragma-monitoring?rev=fab5233#fab52331b4f13bdab47fa16c0e6c9a2be5a5fd99"
 dependencies = [
  "arc-swap",
  "axum",

--- a/infra/pragma-node/postgres_migrations/01-init.sql
+++ b/infra/pragma-node/postgres_migrations/01-init.sql
@@ -4,10 +4,10 @@ CREATE TABLE mainnet_spot_entry (
     data_id character varying(255) NOT NULL,
     block_hash character varying(255),
     block_number bigint,
-    block_timestamp TIMESTAMPTZ,
+    block_timestamp timestamp without time zone,
     transaction_hash character varying(255),
     price numeric,
-    timestamp TIMESTAMPTZ,
+    timestamp timestamp without time zone,
     publisher character varying(255),
     source character varying(255),
     volume numeric,
@@ -20,10 +20,10 @@ CREATE TABLE spot_entry (
     data_id character varying(255) NOT NULL,
     block_hash character varying(255),
     block_number bigint,
-    block_timestamp TIMESTAMPTZ,
+    block_timestamp timestamp without time zone,
     transaction_hash character varying(255),
     price numeric,
-    timestamp TIMESTAMPTZ,
+    timestamp timestamp without time zone,
     publisher character varying(255),
     source character varying(255),
     volume numeric,
@@ -37,15 +37,15 @@ CREATE TABLE mainnet_future_entry (
     data_id character varying(255),
     block_hash character varying(255),
     block_number bigint,
-    block_timestamp TIMESTAMPTZ,
+    block_timestamp timestamp without time zone,
     transaction_hash character varying(255),
     price numeric,
-    timestamp TIMESTAMPTZ,
+    timestamp timestamp without time zone,
     publisher character varying(255),
     source character varying(255),
     volume numeric,
     _cursor bigint,
-    expiration_timestamp TIMESTAMPTZ
+    expiration_timestamp timestamp without time zone
 );
 
 CREATE TABLE future_entry (
@@ -54,15 +54,15 @@ CREATE TABLE future_entry (
     data_id character varying(255),
     block_hash character varying(255),
     block_number bigint,
-    block_timestamp TIMESTAMPTZ,
+    block_timestamp timestamp without time zone,
     transaction_hash character varying(255),
     price numeric,
-    timestamp TIMESTAMPTZ,
+    timestamp timestamp without time zone,
     publisher character varying(255),
     source character varying(255),
     volume numeric,
     _cursor bigint,
-    expiration_timestamp TIMESTAMPTZ
+    expiration_timestamp timestamp without time zone
 );
 
 CREATE TABLE mainnet_spot_checkpoints (
@@ -71,13 +71,13 @@ CREATE TABLE mainnet_spot_checkpoints (
     data_id character varying(255) NOT NULL,
     block_hash character varying(255),
     block_number bigint,
-    block_timestamp TIMESTAMPTZ,
+    block_timestamp timestamp without time zone,
     transaction_hash character varying(255),
     price numeric,
     sender_address character varying(255),
     aggregation_mode numeric,
     _cursor bigint,
-    timestamp TIMESTAMPTZ,
+    timestamp timestamp without time zone,
     nb_sources_aggregated numeric
 );
 
@@ -87,13 +87,13 @@ CREATE TABLE spot_checkpoints (
     data_id character varying(255) NOT NULL,
     block_hash character varying(255),
     block_number bigint,
-    block_timestamp TIMESTAMPTZ,
+    block_timestamp timestamp without time zone,
     transaction_hash character varying(255),
     price numeric,
     sender_address character varying(255),
     aggregation_mode numeric,
     _cursor bigint,
-    timestamp TIMESTAMPTZ,
+    timestamp timestamp without time zone,
     nb_sources_aggregated numeric
 );
 
@@ -101,13 +101,13 @@ CREATE TABLE vrf_requests (
     network character varying(255),
     request_id numeric,
     seed numeric,
-    created_at TIMESTAMPTZ,
+    created_at timestamp without time zone,
     created_at_tx character varying(255),
     callback_address character varying(255),
     callback_fee_limit numeric,
     num_words numeric,
     requestor_address character varying(255),
-    updated_at TIMESTAMPTZ,
+    updated_at timestamp without time zone,
     updated_at_tx character varying(255),
     status numeric,
     minimum_block_number numeric,

--- a/pragma-common/src/types.rs
+++ b/pragma-common/src/types.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, Timelike, Utc};
+use chrono::{NaiveDateTime, Timelike};
 use serde::Deserialize;
 use utoipa::ToSchema;
 
@@ -64,7 +64,7 @@ impl Interval {
     /// This function ensures that the given datetime is aligned to the self interval.
     /// For example, if the interval is 15 minutes, a datetime like 20:17 will be
     /// adjusted to 20:15, so that it falls on the boundary of the interval.
-    pub fn align_timestamp(&self, dt: DateTime<Utc>) -> DateTime<Utc> {
+    pub fn align_timestamp(&self, dt: NaiveDateTime) -> NaiveDateTime {
         let interval_minutes = self.to_minutes();
         let dt_minutes = dt.minute() as i64;
         let total_minutes = dt.hour() as i64 * 60 + dt_minutes;
@@ -85,7 +85,7 @@ impl Interval {
 #[cfg(test)]
 mod tests {
     use super::Interval;
-    use chrono::{DateTime, Utc};
+    use chrono::{DateTime, NaiveDateTime};
 
     #[test]
     fn test_align_timestamp() {
@@ -93,45 +93,45 @@ mod tests {
             (
                 Interval::OneMinute,
                 vec![
-                    ("2021-01-01T00:00:00Z", "2021-01-01 00:00:00 UTC"),
-                    ("2021-01-01T00:00:30Z", "2021-01-01 00:00:00 UTC"),
-                    ("2021-01-01T00:01:00Z", "2021-01-01 00:01:00 UTC"),
-                    ("2021-01-01T00:01:30Z", "2021-01-01 00:01:00 UTC"),
+                    ("2021-01-01T00:00:00Z", "2021-01-01 00:00:00"),
+                    ("2021-01-01T00:00:30Z", "2021-01-01 00:00:00"),
+                    ("2021-01-01T00:01:00Z", "2021-01-01 00:01:00"),
+                    ("2021-01-01T00:01:30Z", "2021-01-01 00:01:00"),
                 ],
             ),
             (
                 Interval::FifteenMinutes,
                 vec![
-                    ("2021-01-01T00:00:00Z", "2021-01-01 00:00:00 UTC"),
-                    ("2021-01-01T00:00:30Z", "2021-01-01 00:00:00 UTC"),
-                    ("2021-01-01T00:01:30Z", "2021-01-01 00:00:00 UTC"),
-                    ("2021-01-01T00:00:30Z", "2021-01-01 00:00:00 UTC"),
-                    ("2021-01-01T00:15:00Z", "2021-01-01 00:15:00 UTC"),
-                    ("2021-01-01T00:22:30Z", "2021-01-01 00:15:00 UTC"),
+                    ("2021-01-01T00:00:00Z", "2021-01-01 00:00:00"),
+                    ("2021-01-01T00:00:30Z", "2021-01-01 00:00:00"),
+                    ("2021-01-01T00:01:30Z", "2021-01-01 00:00:00"),
+                    ("2021-01-01T00:00:30Z", "2021-01-01 00:00:00"),
+                    ("2021-01-01T00:15:00Z", "2021-01-01 00:15:00"),
+                    ("2021-01-01T00:22:30Z", "2021-01-01 00:15:00"),
                 ],
             ),
             (
                 Interval::OneHour,
                 vec![
-                    ("2021-01-01T00:00:00Z", "2021-01-01 00:00:00 UTC"),
-                    ("2021-01-01T00:30:00Z", "2021-01-01 00:00:00 UTC"),
-                    ("2021-01-01T01:00:00Z", "2021-01-01 01:00:00 UTC"),
-                    ("2021-01-01T01:30:00Z", "2021-01-01 01:00:00 UTC"),
+                    ("2021-01-01T00:00:00Z", "2021-01-01 00:00:00"),
+                    ("2021-01-01T00:30:00Z", "2021-01-01 00:00:00"),
+                    ("2021-01-01T01:00:00Z", "2021-01-01 01:00:00"),
+                    ("2021-01-01T01:30:00Z", "2021-01-01 01:00:00"),
                 ],
             ),
             (
                 Interval::TwoHours,
                 vec![
-                    ("2021-01-01T00:00:00Z", "2021-01-01 00:00:00 UTC"),
-                    ("2021-01-01T01:30:00Z", "2021-01-01 00:00:00 UTC"),
-                    ("2021-01-01T02:00:00Z", "2021-01-01 02:00:00 UTC"),
-                    ("2021-01-01T02:30:00Z", "2021-01-01 02:00:00 UTC"),
+                    ("2021-01-01T00:00:00Z", "2021-01-01 00:00:00"),
+                    ("2021-01-01T01:30:00Z", "2021-01-01 00:00:00"),
+                    ("2021-01-01T02:00:00Z", "2021-01-01 02:00:00"),
+                    ("2021-01-01T02:30:00Z", "2021-01-01 02:00:00"),
                 ],
             ),
         ];
         for (interval, test_case) in test_inputs.iter() {
             for (input, expected) in test_case.iter() {
-                let dt: DateTime<Utc> = DateTime::parse_from_rfc3339(input).unwrap().to_utc();
+                let dt: NaiveDateTime = DateTime::parse_from_rfc3339(input).unwrap().naive_utc();
                 let aligned_dt = interval.align_timestamp(dt);
                 assert_eq!(aligned_dt.to_string(), *expected);
             }

--- a/pragma-entities/src/dto/entry.rs
+++ b/pragma-entities/src/dto/entry.rs
@@ -27,7 +27,7 @@ impl From<crate::Entry> for Entry {
             pair_id: entry.pair_id,
             publisher: entry.publisher,
             source: entry.source,
-            timestamp: entry.timestamp.timestamp_millis() as u64,
+            timestamp: entry.timestamp.and_utc().timestamp_millis() as u64,
             price: entry.price.to_u128().unwrap_or(0), // change default value ?
         }
     }

--- a/pragma-entities/src/models/entry.rs
+++ b/pragma-entities/src/models/entry.rs
@@ -2,7 +2,7 @@ use crate::dto::entry as dto;
 use crate::models::DieselResult;
 use crate::schema::entries;
 use bigdecimal::BigDecimal;
-use chrono::{DateTime, Utc};
+use diesel::internal::derives::multiconnection::chrono::NaiveDateTime;
 use diesel::upsert::excluded;
 use diesel::{
     AsChangeset, ExpressionMethods, Insertable, PgConnection, PgTextExpressionMethods, QueryDsl,
@@ -19,7 +19,7 @@ pub struct Entry {
     pub pair_id: String,
     pub publisher: String,
     pub source: String,
-    pub timestamp: DateTime<Utc>,
+    pub timestamp: NaiveDateTime,
     pub price: BigDecimal,
 }
 
@@ -29,7 +29,7 @@ pub struct NewEntry {
     pub pair_id: String,
     pub publisher: String,
     pub source: String,
-    pub timestamp: DateTime<Utc>,
+    pub timestamp: NaiveDateTime,
     pub price: BigDecimal,
 }
 

--- a/pragma-node/Cargo.toml
+++ b/pragma-node/Cargo.toml
@@ -21,7 +21,7 @@ envy = "0.4.2"
 lazy_static = "1.4.0"
 pragma-common = { path = "../pragma-common", version = "1.0.0" }
 pragma-entities = { path = "../pragma-entities", version = "1.0.0" }
-pragma-monitoring = { git = "https://github.com/akhercha/pragma-monitoring", branch = "fix/revert_datetime_update" }
+pragma-monitoring = { git = "https://github.com/astraly-labs/pragma-monitoring", rev = "fab5233" }
 rdkafka = "0.36.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["arbitrary_precision"] }

--- a/pragma-node/Cargo.toml
+++ b/pragma-node/Cargo.toml
@@ -21,7 +21,7 @@ envy = "0.4.2"
 lazy_static = "1.4.0"
 pragma-common = { path = "../pragma-common", version = "1.0.0" }
 pragma-entities = { path = "../pragma-entities", version = "1.0.0" }
-pragma-monitoring = { git = "https://github.com/astraly-labs/pragma-monitoring", rev = "c475da8" }
+pragma-monitoring = { git = "https://github.com/akhercha/pragma-monitoring", branch = "fix/revert_datetime_update" }
 rdkafka = "0.36.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["arbitrary_precision"] }

--- a/pragma-node/src/handlers/entries/create_entry.rs
+++ b/pragma-node/src/handlers/entries/create_entry.rs
@@ -145,7 +145,7 @@ pub async fn create_entries(
         .iter()
         .map(|entry| {
             let dt = match DateTime::<Utc>::from_timestamp(entry.base.timestamp as i64, 0) {
-                Some(dt) => dt,
+                Some(dt) => dt.naive_utc(),
                 None => return Err(EntryError::InvalidTimestamp),
             };
 

--- a/pragma-node/src/handlers/entries/get_entry.rs
+++ b/pragma-node/src/handlers/entries/get_entry.rs
@@ -84,7 +84,7 @@ fn adapt_entry_to_entry_response(
 ) -> GetEntryResponse {
     GetEntryResponse {
         pair_id,
-        timestamp: entry.time.timestamp_millis() as u64,
+        timestamp: entry.time.and_utc().timestamp_millis() as u64,
         num_sources_aggregated: entry.num_sources as usize,
         price: format!(
             "0x{}",

--- a/pragma-node/src/handlers/entries/utils.rs
+++ b/pragma-node/src/handlers/entries/utils.rs
@@ -1,5 +1,5 @@
 use bigdecimal::{BigDecimal, ToPrimitive};
-use chrono::{DateTime, Utc};
+use chrono::NaiveDateTime;
 use std::collections::HashMap;
 
 use crate::infra::repositories::entry_repository::MedianEntry;
@@ -49,7 +49,7 @@ pub(crate) fn get_decimals_for_pair(
 #[allow(dead_code)]
 pub(crate) fn compute_median_price_and_time(
     entries: &mut Vec<MedianEntry>,
-) -> Option<(BigDecimal, DateTime<Utc>)> {
+) -> Option<(BigDecimal, NaiveDateTime)> {
     if entries.is_empty() {
         return None;
     }
@@ -108,7 +108,7 @@ mod tests {
 
     fn new_entry(median_price: u32, timestamp: i64) -> MedianEntry {
         MedianEntry {
-            time: DateTime::from_timestamp(timestamp, 0).unwrap(),
+            time: DateTime::from_timestamp(timestamp, 0).unwrap().naive_utc(),
             median_price: median_price.into(),
             num_sources: 5,
         }

--- a/pragma-node/src/infra/repositories/onchain_repository.rs
+++ b/pragma-node/src/infra/repositories/onchain_repository.rs
@@ -1,9 +1,9 @@
 use std::collections::HashMap;
 
 use bigdecimal::BigDecimal;
-use chrono::{DateTime, Duration, Utc};
+use chrono::{Duration, NaiveDateTime, Utc};
 use deadpool_diesel::postgres::Pool;
-use diesel::sql_types::{BigInt, Integer, Numeric, Text, Timestamptz, VarChar};
+use diesel::sql_types::{BigInt, Integer, Numeric, Text, Timestamp, VarChar};
 use diesel::{Queryable, QueryableByName, RunQueryDsl};
 
 use pragma_common::types::{AggregationMode, DataType, Interval, Network};
@@ -42,7 +42,7 @@ impl From<SpotEntryWithAggregatedPrice> for OnchainEntry {
             source: entry.spot_entry.source,
             price: entry.spot_entry.price.to_string(),
             tx_hash: entry.spot_entry.transaction_hash,
-            timestamp: entry.spot_entry.timestamp.timestamp() as u64,
+            timestamp: entry.spot_entry.timestamp.and_utc().timestamp() as u64,
         }
     }
 }
@@ -142,8 +142,8 @@ pub async fn get_sources_and_aggregate(
 
 #[derive(Queryable, QueryableByName)]
 struct EntryTimestamp {
-    #[diesel(sql_type = Timestamptz)]
-    pub timestamp: DateTime<Utc>,
+    #[diesel(sql_type = Timestamp)]
+    pub timestamp: chrono::NaiveDateTime,
 }
 
 // TODO(akhercha): Only works for Spot entries
@@ -178,7 +178,7 @@ pub async fn get_last_updated_timestamp(
         .map_err(adapt_infra_error)?;
 
     let most_recent_entry = raw_entry.first().ok_or(InfraError::NotFound)?;
-    Ok(most_recent_entry.timestamp.timestamp() as u64)
+    Ok(most_recent_entry.timestamp.and_utc().timestamp() as u64)
 }
 
 #[derive(Queryable, QueryableByName)]
@@ -187,8 +187,8 @@ struct RawCheckpoint {
     pub transaction_hash: String,
     #[diesel(sql_type = Numeric)]
     pub price: BigDecimal,
-    #[diesel(sql_type = Timestamptz)]
-    pub timestamp: DateTime<Utc>,
+    #[diesel(sql_type = Timestamp)]
+    pub timestamp: chrono::NaiveDateTime,
     #[diesel(sql_type = VarChar)]
     pub sender_address: String,
 }
@@ -198,7 +198,7 @@ impl RawCheckpoint {
         Checkpoint {
             tx_hash: self.transaction_hash.clone(),
             price: format_bigdecimal_price(self.price.clone(), decimals),
-            timestamp: self.timestamp.timestamp() as u64,
+            timestamp: self.timestamp.and_utc().timestamp() as u64,
             sender_address: self.sender_address.clone(),
         }
     }
@@ -303,8 +303,8 @@ pub struct RawLastPublisherEntryForPair {
     pub price: BigDecimal,
     #[diesel(sql_type = VarChar)]
     pub source: String,
-    #[diesel(sql_type = Timestamptz)]
-    pub last_updated_timestamp: DateTime<Utc>,
+    #[diesel(sql_type = Timestamp)]
+    pub last_updated_timestamp: chrono::NaiveDateTime,
 }
 
 impl RawLastPublisherEntryForPair {
@@ -312,7 +312,7 @@ impl RawLastPublisherEntryForPair {
         let decimals = get_decimals_for_pair(currencies, &self.pair_id);
         PublisherEntry {
             pair_id: self.pair_id.clone(),
-            last_updated_timestamp: self.last_updated_timestamp.timestamp() as u64,
+            last_updated_timestamp: self.last_updated_timestamp.and_utc().timestamp() as u64,
             price: format_bigdecimal_price(self.price.clone(), decimals),
             source: self.source.clone(),
             decimals,
@@ -486,7 +486,7 @@ pub async fn get_ohlc(
     interval: Interval,
     data_to_retrieve: i64,
 ) -> Result<(), InfraError> {
-    let now = Utc::now();
+    let now = Utc::now().naive_utc();
     let aligned_current_timestamp = interval.align_timestamp(now);
     let start_timestamp = if data_to_retrieve > 1 {
         aligned_current_timestamp
@@ -512,7 +512,7 @@ async fn get_entries_from_timestamp(
     pool: &Pool,
     network: Network,
     pair_id: &str,
-    start_timestamp: DateTime<Utc>,
+    start_timestamp: NaiveDateTime,
 ) -> Result<Vec<SpotEntry>, InfraError> {
     let raw_sql = format!(
         r#"
@@ -559,8 +559,8 @@ fn update_ohlc_data(
     ohlc_data: &mut Vec<OHLCEntry>,
     entries: Vec<SpotEntry>,
     interval: Interval,
-    now: DateTime<Utc>,
-    mut start_timestamp: DateTime<Utc>,
+    now: NaiveDateTime,
+    mut start_timestamp: NaiveDateTime,
     only_update_last: bool,
 ) {
     let interval_duration = Duration::minutes(interval.to_minutes());
@@ -608,7 +608,7 @@ fn update_ohlc_data(
 
 fn compute_ohlc_from_entries(
     entries: &[&SpotEntry],
-    end_interval: DateTime<Utc>,
+    end_interval: NaiveDateTime,
     last_ohlc_computed: Option<&OHLCEntry>,
 ) -> Option<OHLCEntry> {
     if entries.is_empty() && last_ohlc_computed.is_none() {
@@ -653,8 +653,8 @@ fn compute_ohlc_from_entries(
 /// The interval is defined by the start_timestamp and the end_current_interval.
 fn get_entries_for_interval(
     entries: &[SpotEntry],
-    start_timestamp: DateTime<Utc>,
-    end_current_interval: DateTime<Utc>,
+    start_timestamp: NaiveDateTime,
+    end_current_interval: NaiveDateTime,
 ) -> Vec<&SpotEntry> {
     entries
         .iter()


### PR DESCRIPTION
We have alerts in our testnet about entries not being published for a long time even though they are.

Probably related to this timezone change.

We decided to revert it.