### PR TITLE
fix: invalid timestamp

### DIFF
--- a/pragma-entities/src/dto/entry.rs
+++ b/pragma-entities/src/dto/entry.rs
@@ -27,7 +27,7 @@ impl From<crate::Entry> for Entry {
             pair_id: entry.pair_id,
             publisher: entry.publisher,
             source: entry.source,
-            timestamp: entry.timestamp.and_utc().timestamp_millis() as u64,
+            timestamp: entry.timestamp.and_utc().timestamp() as u64,
             price: entry.price.to_u128().unwrap_or(0), // change default value ?
         }
     }

--- a/pragma-node/src/handlers/entries/get_entry.rs
+++ b/pragma-node/src/handlers/entries/get_entry.rs
@@ -56,7 +56,6 @@ pub async fn get_entry(
 
     let is_routing = params.routing.unwrap_or(false);
 
-    // Validate given timestamp
     if timestamp > now {
         return Err(EntryError::InvalidTimestamp);
     }

--- a/pragma-node/src/handlers/entries/get_entry.rs
+++ b/pragma-node/src/handlers/entries/get_entry.rs
@@ -34,7 +34,7 @@ pub async fn get_entry(
     // Construct pair id
     let pair_id = currency_pair_to_pair_id(&pair.0, &pair.1);
 
-    let now = chrono::Utc::now().timestamp_millis() as u64;
+    let now = chrono::Utc::now().timestamp() as u64;
 
     let timestamp = if let Some(timestamp) = params.timestamp {
         timestamp

--- a/pragma-node/src/handlers/entries/get_entry.rs
+++ b/pragma-node/src/handlers/entries/get_entry.rs
@@ -84,7 +84,7 @@ fn adapt_entry_to_entry_response(
 ) -> GetEntryResponse {
     GetEntryResponse {
         pair_id,
-        timestamp: entry.time.and_utc().timestamp_millis() as u64,
+        timestamp: entry.time.and_utc().timestamp() as u64,
         num_sources_aggregated: entry.num_sources as usize,
         price: format!(
             "0x{}",

--- a/pragma-node/src/handlers/entries/get_ohlc.rs
+++ b/pragma-node/src/handlers/entries/get_ohlc.rs
@@ -31,7 +31,7 @@ pub async fn get_ohlc(
     // Construct pair id
     let pair_id = currency_pair_to_pair_id(&pair.0, &pair.1);
 
-    let now = chrono::Utc::now().timestamp_millis() as u64;
+    let now = chrono::Utc::now().timestamp() as u64;
 
     let timestamp = if let Some(timestamp) = params.timestamp {
         timestamp

--- a/pragma-node/src/handlers/entries/mod.rs
+++ b/pragma-node/src/handlers/entries/mod.rs
@@ -143,7 +143,7 @@ pub struct GetEntryParams {
 impl Default for GetEntryParams {
     fn default() -> Self {
         Self {
-            timestamp: Some(chrono::Utc::now().timestamp_millis() as u64),
+            timestamp: Some(chrono::Utc::now().timestamp() as u64),
             interval: Some(Interval::default()),
             routing: Some(false),
             aggregation: Some(AggregationMode::default()),


### PR DESCRIPTION
Resolves #57 

Timestamps are now in seconds to align with SDK spec