### PR TITLE
feat: ip rate limiting on ws endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -823,6 +823,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1318,6 +1331,26 @@ name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "governor"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68a7f542ee6b35af73b06abc0dad1c1bae89964e4e253bc4b587b91c9637867b"
+dependencies = [
+ "cfg-if",
+ "dashmap",
+ "futures",
+ "futures-timer",
+ "no-std-compat",
+ "nonzero_ext",
+ "parking_lot",
+ "portable-atomic",
+ "quanta",
+ "rand",
+ "smallvec",
+ "spinning_top",
+]
 
 [[package]]
 name = "h2"
@@ -1863,6 +1896,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "no-std-compat"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
+
+[[package]]
+name = "nonzero_ext"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2165,6 +2210,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
+name = "portable-atomic"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
+
+[[package]]
 name = "postgres-protocol"
 version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2314,7 +2365,9 @@ dependencies = [
  "dotenvy",
  "envy",
  "futures-util",
+ "governor",
  "lazy_static",
+ "nonzero_ext",
  "pragma-common",
  "pragma-entities",
  "pragma-monitoring",
@@ -2424,6 +2477,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
+name = "quanta"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5167a477619228a0b284fac2674e3c388cba90631d7b7de620e6f1fcd08da5"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2477,6 +2545,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e29830cbb1290e404f24c73af91c5d8d631ce7e128691e9477556b540cd01ecd"
+dependencies = [
+ "bitflags 2.5.0",
 ]
 
 [[package]]
@@ -3131,6 +3208,15 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "spinning_top"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96d2d1d716fb500937168cc09353ffdc7a012be8475ac7308e1bdf0e3923300"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "starknet"

--- a/pragma-entities/src/models/checkpoint_error.rs
+++ b/pragma-entities/src/models/checkpoint_error.rs
@@ -21,6 +21,8 @@ impl From<InfraError> for CheckpointError {
             InfraError::InternalServerError => Self::InternalServerError,
             InfraError::NotFound => Self::NotFound,
             InfraError::InvalidTimeStamp => Self::InternalServerError,
+            InfraError::NonZeroU32Conversion(_) => Self::InternalServerError,
+            InfraError::AxumError(_) => Self::InternalServerError,
         }
     }
 }

--- a/pragma-entities/src/models/entries/entry_error.rs
+++ b/pragma-entities/src/models/entries/entry_error.rs
@@ -49,6 +49,8 @@ impl From<InfraError> for EntryError {
             InfraError::InternalServerError => Self::InternalServerError,
             InfraError::NotFound => Self::NotFound("Unknown".to_string()),
             InfraError::InvalidTimeStamp => Self::InternalServerError,
+            InfraError::NonZeroU32Conversion(_) => Self::InternalServerError,
+            InfraError::AxumError(_) => Self::InternalServerError,
         }
     }
 }

--- a/pragma-node/Cargo.toml
+++ b/pragma-node/Cargo.toml
@@ -22,7 +22,9 @@ diesel_migrations = "2"
 dotenvy = "0.15"
 envy = "0.4.2"
 futures-util = "0.3.30"
+governor = { version = "0.6.0" }
 lazy_static = "1.4.0"
+nonzero_ext = { version = "0.3.0" }
 pragma-common = { path = "../pragma-common", version = "1.0.0" }
 pragma-entities = { path = "../pragma-entities", version = "1.0.0" }
 pragma-monitoring = { git = "https://github.com/astraly-labs/pragma-monitoring", rev = "fab5233" }

--- a/pragma-node/src/handlers/entries/get_onchain/ohlc.rs
+++ b/pragma-node/src/handlers/entries/get_onchain/ohlc.rs
@@ -1,8 +1,10 @@
 use std::net::SocketAddr;
+use std::num::NonZeroU32;
 use std::sync::Arc;
 
 use axum::extract::{ConnectInfo, State};
 use axum::response::IntoResponse;
+use futures_util::SinkExt;
 use pragma_entities::InfraError;
 use serde::{Deserialize, Serialize};
 
@@ -10,6 +12,7 @@ use pragma_common::types::{Interval, Network};
 
 use crate::infra::repositories::entry_repository::OHLCEntry;
 use crate::infra::repositories::onchain_repository;
+use crate::types::ws::metrics::{self, Interaction, Status};
 use crate::types::ws::{ChannelHandler, Subscriber, SubscriptionType};
 use crate::utils::is_onchain_existing_pair;
 use crate::AppState;
@@ -146,6 +149,29 @@ impl ChannelHandler<SubscriptionState, SubscriptionRequest, InfraError> for WsOH
 
         match serde_json::to_string(&ohlc_data) {
             Ok(json_response) => {
+                let ip_addr = subscriber.ip_address;
+
+                // Close the connection if rate limit is exceeded.
+                if subscriber.rate_limiter.check_key_n(
+                    &subscriber.ip_address,
+                    NonZeroU32::new(json_response.len().try_into()?)
+                        .ok_or(InfraError::InternalServerError)?,
+                ) != Ok(Ok(()))
+                {
+                    tracing::info!(
+                        subscriber_id = %subscriber.id,
+                        ip = %ip_addr,
+                        "Rate limit exceeded. Closing connection.",
+                    );
+
+                    metrics::record_ws_interaction(Interaction::RateLimit, Status::Error);
+
+                    subscriber.send_err("Rate limit exceeded.").await;
+                    subscriber.sender.close().await?;
+                    subscriber.closed = true;
+                    return Ok(());
+                }
+
                 if subscriber.send_msg(json_response).await.is_err() {
                     subscriber.send_err("Could not send prices.").await;
                 }

--- a/pragma-node/src/handlers/entries/get_volatility.rs
+++ b/pragma-node/src/handlers/entries/get_volatility.rs
@@ -54,24 +54,13 @@ pub async fn get_volatility(
         volatility_query.start,
         volatility_query.end,
     )
-    .await
-    .map_err(|db_error| match db_error {
-        InfraError::InternalServerError => EntryError::InternalServerError,
-        InfraError::NotFound => EntryError::NotFound(pair_id.clone()),
-        InfraError::InvalidTimeStamp => EntryError::InvalidTimestamp,
-    })?;
+    .await?;
 
     if entries.is_empty() {
         return Err(EntryError::UnknownPairId(pair_id));
     }
 
-    let decimals = entry_repository::get_decimals(&state.offchain_pool, &pair_id)
-        .await
-        .map_err(|db_error| match db_error {
-            InfraError::InternalServerError => EntryError::InternalServerError,
-            InfraError::NotFound => EntryError::NotFound(pair_id.clone()),
-            InfraError::InvalidTimeStamp => EntryError::InvalidTimestamp,
-        })?;
+    let decimals = entry_repository::get_decimals(&state.offchain_pool, &pair_id).await?;
 
     Ok(Json(adapt_entry_to_entry_response(
         pair_id, &entries, decimals,

--- a/pragma-node/src/handlers/entries/get_volatility.rs
+++ b/pragma-node/src/handlers/entries/get_volatility.rs
@@ -7,7 +7,7 @@ use crate::handlers::entries::GetVolatilityResponse;
 use crate::infra::repositories::entry_repository::{self, MedianEntry};
 use crate::utils::PathExtractor;
 use crate::AppState;
-use pragma_entities::{error::InfraError, EntryError, VolatilityError};
+use pragma_entities::{EntryError, VolatilityError};
 
 use crate::utils::{compute_volatility, currency_pair_to_pair_id};
 

--- a/pragma-node/src/types/ws/metrics.rs
+++ b/pragma-node/src/types/ws/metrics.rs
@@ -20,6 +20,8 @@ pub enum Interaction {
     ClientMessageProcess,
     #[strum(to_string = "Channel Update")]
     ChannelUpdate,
+    #[strum(to_string = "Rate Limit Exceeded")]
+    RateLimit,
 }
 
 #[derive(strum::Display, Clone, Debug, Hash, PartialEq, Eq)]


### PR DESCRIPTION
Resolves #70 

## Changes

- Adds rate limiting in terms of bytes that can be sent to the client

We could have added a limit in terms of connections that can be made with the server, but it's not useful as we already limit the bytes there will be a theoretical limit in the number of connections that can be made anyways.