### PR TITLE
fix: OHLC computation method

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -34,6 +34,8 @@ services:
       - DATABASE_MAX_CONN=5
       - TOPIC=pragma-data
       - KAFKA_BROKERS=pragma-kafka:9092
+      - TIMESCALE_DATABASE_URL=postgres://postgres:test-password@timescale-db:5432/pragma
+      - POSTGRES_DATABASE_URL=postgres://postgres:test-password@postgre-db:5432/pragma
     depends_on:
       pragma-kafka:
         condition: service_healthy
@@ -141,11 +143,12 @@ services:
   pragma-ingestor-1:
     container_name: "pragma-ingestor-1"
     environment:
-      - POSTGRES_DATABASE_URL=postgres://postgres:test-password@db:5432/pragma
       - DATABASE_MAX_CONN=5
       - BROKERS=pragma-kafka:9092
       - TOPIC=pragma-data
       - GROUP_ID=pragma-data
+      - TIMESCALE_DATABASE_URL=postgres://postgres:test-password@timescale-db:5432/pragma
+      - POSTGRES_DATABASE_URL=postgres://postgres:test-password@postgre-db:5432/pragma
     depends_on:
       pragma-kafka:
         condition: service_healthy

--- a/pragma-entities/migrations/2024-07-02-232003_add_median_aggregates/down.sql
+++ b/pragma-entities/migrations/2024-07-02-232003_add_median_aggregates/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+DROP MATERIALIZED VIEW IF EXISTS price_10_s_agg;

--- a/pragma-entities/migrations/2024-07-02-232003_add_median_aggregates/up.sql
+++ b/pragma-entities/migrations/2024-07-02-232003_add_median_aggregates/up.sql
@@ -10,8 +10,6 @@ FROM entries
 GROUP BY bucket, pair_id
 WITH NO DATA;
 
-CALL refresh_continuous_aggregate('price_10_s_agg', NULL, localtimestamp - INTERVAL '1 day');
-
 SELECT add_continuous_aggregate_policy('price_10_s_agg',
   start_offset => INTERVAL '1 day',
   end_offset => INTERVAL '10 seconds',

--- a/pragma-entities/migrations/2024-07-02-232003_add_median_aggregates/up.sql
+++ b/pragma-entities/migrations/2024-07-02-232003_add_median_aggregates/up.sql
@@ -1,0 +1,18 @@
+-- Your SQL goes here
+CREATE MATERIALIZED VIEW price_10_s_agg
+WITH (timescaledb.continuous, timescaledb.materialized_only = false)
+AS SELECT 
+    pair_id,
+    time_bucket('10 seconds'::interval, timestamp) as bucket,
+    approx_percentile(0.5, percentile_agg(price))::numeric AS median_price,
+    COUNT(DISTINCT source) as num_sources
+FROM entries
+GROUP BY bucket, pair_id
+WITH NO DATA;
+
+CALL refresh_continuous_aggregate('price_10_s_agg', NULL, localtimestamp - INTERVAL '1 day');
+
+SELECT add_continuous_aggregate_policy('price_10_s_agg',
+  start_offset => INTERVAL '1 day',
+  end_offset => INTERVAL '10 seconds',
+  schedule_interval => INTERVAL '10 seconds');

--- a/pragma-entities/migrations/2024-07-02-232723_new_ohlc_aggs/down.sql
+++ b/pragma-entities/migrations/2024-07-02-232723_new_ohlc_aggs/down.sql
@@ -1,0 +1,6 @@
+-- This file should undo anything in `up.sql`
+DROP MATERIALIZED VIEW IF EXISTS one_day_candle_new;
+DROP MATERIALIZED VIEW IF EXISTS one_hour_candle_new;
+DROP MATERIALIZED VIEW IF EXISTS fifteen_minute_candle_new;
+DROP MATERIALIZED VIEW IF EXISTS five_minute_candle_new;
+DROP MATERIALIZED VIEW IF EXISTS one_minute_candle_new;

--- a/pragma-entities/migrations/2024-07-02-232723_new_ohlc_aggs/up.sql
+++ b/pragma-entities/migrations/2024-07-02-232723_new_ohlc_aggs/up.sql
@@ -1,96 +1,96 @@
 -- Your SQL goes here
 -- 1 day candle
-CREATE MATERIALIZED VIEW 1_day_candle_new
+CREATE MATERIALIZED VIEW new_1_day_candle
 WITH (timescaledb.continuous) AS
     SELECT
-        time_bucket('1 day', bucket) AS bucket,
+        time_bucket('1 day', bucket) AS ohlc_bucket,
         pair_id,
-        FIRST(price, bucket) AS "open",
-        MAX(price) AS high,
-        MIN(price) AS low,
-        LAST(price, bucket) AS "close"
+        FIRST(median_price, bucket) AS "open",
+        MAX(median_price) AS high,
+        MIN(median_price) AS low,
+        LAST(median_price, bucket) AS "close"
     FROM price_10_s_agg
-    GROUP BY bucket, pair_id
+    GROUP BY ohlc_bucket, pair_id
     WITH NO DATA;
 
 
-SELECT add_continuous_aggregate_policy('1_day_candle_new',
+SELECT add_continuous_aggregate_policy('new_1_day_candle',
     start_offset => INTERVAL '3 days',
     end_offset => INTERVAL '1 day',
     schedule_interval => INTERVAL '1 day');
 
 -- 1 hour candle
-CREATE MATERIALIZED VIEW 1_h_candle_new
+CREATE MATERIALIZED VIEW new_1_h_candle
 WITH (timescaledb.continuous) AS
     SELECT
-        time_bucket('1 hour', bucket) AS bucket,
+        time_bucket('1 hour', bucket) AS ohlc_bucket,
         pair_id,
-        FIRST(price, bucket) AS "open",
-        MAX(price) AS high,
-        MIN(price) AS low,
-        LAST(price, bucket) AS "close"
+        FIRST(median_price, bucket) AS "open",
+        MAX(median_price) AS high,
+        MIN(median_price) AS low,
+        LAST(median_price, bucket) AS "close"
     FROM price_10_s_agg
-    GROUP BY bucket, pair_id
+    GROUP BY ohlc_bucket, pair_id
     WITH NO DATA;
 
-SELECT add_continuous_aggregate_policy('1_h_candle_new',
+SELECT add_continuous_aggregate_policy('new_1_h_candle',
     start_offset => INTERVAL '3 hours',
     end_offset => INTERVAL '1 hour',
     schedule_interval => INTERVAL '1 hour');
 
 -- 15 minute candle
-CREATE MATERIALIZED VIEW 15_min_candle_new
+CREATE MATERIALIZED VIEW new_15_min_candle
 WITH (timescaledb.continuous) AS
     SELECT
-        time_bucket('15 minutes', bucket) AS bucket,
+        time_bucket('15 minutes', bucket) AS ohlc_bucket,
         pair_id,
-        FIRST(price, bucket)::numeric AS "open",
-        MAX(price)::numeric AS high,
-        MIN(price)::numeric AS low,
-        LAST(price, bucket)::numeric AS "close"
+        FIRST(median_price, bucket)::numeric AS "open",
+        MAX(median_price)::numeric AS high,
+        MIN(median_price)::numeric AS low,
+        LAST(median_price, bucket)::numeric AS "close"
     FROM price_10_s_agg
-    GROUP BY bucket, pair_id
+    GROUP BY ohlc_bucket, pair_id
     WITH NO DATA;
 
-SELECT add_continuous_aggregate_policy('15_min_candle_new',
+SELECT add_continuous_aggregate_policy('new_15_min_candle',
     start_offset => INTERVAL '45 minutes',
     end_offset => INTERVAL '15 minutes',
     schedule_interval => INTERVAL '15 minutes');
 
 -- 5 minute candle
-CREATE MATERIALIZED VIEW 5_min_candle_new
+CREATE MATERIALIZED VIEW new_5_min_candle
 WITH (timescaledb.continuous) AS
     SELECT
-        time_bucket('5 minutes', bucket) AS bucket,
+        time_bucket('5 minutes', bucket) AS ohlc_bucket,
         pair_id,
-        FIRST(price, bucket) AS "open",
-        MAX(price) AS high,
-        MIN(price) AS low,
-        LAST(price, bucket) AS "close"
+        FIRST(median_price, bucket) AS "open",
+        MAX(median_price) AS high,
+        MIN(median_price) AS low,
+        LAST(median_price, bucket) AS "close"
     FROM price_10_s_agg
-    GROUP BY bucket, pair_id
+    GROUP BY ohlc_bucket, pair_id
     WITH NO DATA;
 
-SELECT add_continuous_aggregate_policy('5_min_candle_new',
+SELECT add_continuous_aggregate_policy('new_5_min_candle',
     start_offset => INTERVAL '15 minutes',
     end_offset => INTERVAL '5 minutes',
     schedule_interval => INTERVAL '5 minutes');
 
 -- 1 minute candle
-CREATE MATERIALIZED VIEW 1_min_candle_new
+CREATE MATERIALIZED VIEW new_1_min_candle
 WITH (timescaledb.continuous) AS
     SELECT
-        time_bucket('1 minute', bucket) AS bucket,
+        time_bucket('1 minute', bucket) AS ohlc_bucket,
         pair_id,
-        FIRST(price, bucket) AS "open",
-        MAX(price) AS high,
-        MIN(price) AS low,
-        LAST(price, bucket) AS "close"
+        FIRST(median_price, bucket) AS "open",
+        MAX(median_price) AS high,
+        MIN(median_price) AS low,
+        LAST(median_price, bucket) AS "close"
     FROM price_10_s_agg
-    GROUP BY bucket, pair_id
+    GROUP BY ohlc_bucket, pair_id
     WITH NO DATA;
 
-SELECT add_continuous_aggregate_policy('1_min_candle_new',
+SELECT add_continuous_aggregate_policy('new_1_min_candle',
     start_offset => INTERVAL '3 minutes',
     end_offset => INTERVAL '1 minute',
     schedule_interval => INTERVAL '1 minute');

--- a/pragma-entities/migrations/2024-07-02-232723_new_ohlc_aggs/up.sql
+++ b/pragma-entities/migrations/2024-07-02-232723_new_ohlc_aggs/up.sql
@@ -1,0 +1,96 @@
+-- Your SQL goes here
+-- 1 day candle
+CREATE MATERIALIZED VIEW 1_day_candle_new
+WITH (timescaledb.continuous) AS
+    SELECT
+        time_bucket('1 day', bucket) AS bucket,
+        pair_id,
+        FIRST(price, bucket) AS "open",
+        MAX(price) AS high,
+        MIN(price) AS low,
+        LAST(price, bucket) AS "close"
+    FROM price_10_s_agg
+    GROUP BY bucket, pair_id
+    WITH NO DATA;
+
+
+SELECT add_continuous_aggregate_policy('1_day_candle_new',
+    start_offset => INTERVAL '3 days',
+    end_offset => INTERVAL '1 day',
+    schedule_interval => INTERVAL '1 day');
+
+-- 1 hour candle
+CREATE MATERIALIZED VIEW 1_h_candle_new
+WITH (timescaledb.continuous) AS
+    SELECT
+        time_bucket('1 hour', bucket) AS bucket,
+        pair_id,
+        FIRST(price, bucket) AS "open",
+        MAX(price) AS high,
+        MIN(price) AS low,
+        LAST(price, bucket) AS "close"
+    FROM price_10_s_agg
+    GROUP BY bucket, pair_id
+    WITH NO DATA;
+
+SELECT add_continuous_aggregate_policy('1_h_candle_new',
+    start_offset => INTERVAL '3 hours',
+    end_offset => INTERVAL '1 hour',
+    schedule_interval => INTERVAL '1 hour');
+
+-- 15 minute candle
+CREATE MATERIALIZED VIEW 15_min_candle_new
+WITH (timescaledb.continuous) AS
+    SELECT
+        time_bucket('15 minutes', bucket) AS bucket,
+        pair_id,
+        FIRST(price, bucket)::numeric AS "open",
+        MAX(price)::numeric AS high,
+        MIN(price)::numeric AS low,
+        LAST(price, bucket)::numeric AS "close"
+    FROM price_10_s_agg
+    GROUP BY bucket, pair_id
+    WITH NO DATA;
+
+SELECT add_continuous_aggregate_policy('15_min_candle_new',
+    start_offset => INTERVAL '45 minutes',
+    end_offset => INTERVAL '15 minutes',
+    schedule_interval => INTERVAL '15 minutes');
+
+-- 5 minute candle
+CREATE MATERIALIZED VIEW 5_min_candle_new
+WITH (timescaledb.continuous) AS
+    SELECT
+        time_bucket('5 minutes', bucket) AS bucket,
+        pair_id,
+        FIRST(price, bucket) AS "open",
+        MAX(price) AS high,
+        MIN(price) AS low,
+        LAST(price, bucket) AS "close"
+    FROM price_10_s_agg
+    GROUP BY bucket, pair_id
+    WITH NO DATA;
+
+SELECT add_continuous_aggregate_policy('5_min_candle_new',
+    start_offset => INTERVAL '15 minutes',
+    end_offset => INTERVAL '5 minutes',
+    schedule_interval => INTERVAL '5 minutes');
+
+-- 1 minute candle
+CREATE MATERIALIZED VIEW 1_min_candle_new
+WITH (timescaledb.continuous) AS
+    SELECT
+        time_bucket('1 minute', bucket) AS bucket,
+        pair_id,
+        FIRST(price, bucket) AS "open",
+        MAX(price) AS high,
+        MIN(price) AS low,
+        LAST(price, bucket) AS "close"
+    FROM price_10_s_agg
+    GROUP BY bucket, pair_id
+    WITH NO DATA;
+
+SELECT add_continuous_aggregate_policy('1_min_candle_new',
+    start_offset => INTERVAL '3 minutes',
+    end_offset => INTERVAL '1 minute',
+    schedule_interval => INTERVAL '1 minute');

--- a/pragma-node/src/infra/repositories/entry_repository.rs
+++ b/pragma-node/src/infra/repositories/entry_repository.rs
@@ -534,17 +534,17 @@ pub async fn get_ohlc(
         r#"
         -- query the materialized realtime view
         SELECT
-            bucket AS time,
+            ohlc_bucket AS time,
             open,
             high,
             low,
             close
         FROM
-            {}_candle_new
+            new_{}_candle
         WHERE
             pair_id = $1
             AND
-            bucket <= $2
+            ohlc_bucket <= $2
         ORDER BY
             time DESC
         LIMIT 10000;


### PR DESCRIPTION
## Updated

- Our method to compute the OHLC value from the offchain database was wrong. We now compute it from the median price of the entries published every 10s, see `price_10_s_agg`
