### PR TITLE
fix: Updated typed_data following starknet.py bump

### DIFF
--- a/pragma-entities/src/models/entries/entry_error.rs
+++ b/pragma-entities/src/models/entries/entry_error.rs
@@ -27,8 +27,8 @@ pub enum EntryError {
     InvalidSignature(EcdsaVerifyError),
     #[error("could not sign price")]
     InvalidSigner,
-    #[error("unauthorized request")]
-    Unauthorized,
+    #[error("unauthorized request: {0}")]
+    Unauthorized(String),
     #[error("invalid timestamp")]
     InvalidTimestamp,
     #[error("invalid expiry")]
@@ -72,9 +72,9 @@ impl IntoResponse for EntryError {
                 StatusCode::BAD_REQUEST,
                 format!("Invalid signature: {}", err),
             ),
-            Self::Unauthorized => (
+            Self::Unauthorized(reason) => (
                 StatusCode::UNAUTHORIZED,
-                "Unauthorized publisher".to_string(),
+                format!("Unauthorized publisher: {}", reason),
             ),
             Self::InvalidTimestamp => (StatusCode::BAD_REQUEST, "Invalid timestamp".to_string()),
             Self::InvalidExpiry => (StatusCode::BAD_REQUEST, "Invalid expiry".to_string()),

--- a/pragma-node/src/handlers/entries/create_entry.rs
+++ b/pragma-node/src/handlers/entries/create_entry.rs
@@ -8,7 +8,7 @@ use crate::config::config;
 use crate::handlers::entries::{CreateEntryRequest, CreateEntryResponse};
 use crate::infra::kafka;
 use crate::infra::repositories::publisher_repository;
-use crate::utils::{assert_signature_is_valid, JsonExtractor};
+use crate::utils::{assert_legacy_signature_is_valid, assert_signature_is_valid, JsonExtractor};
 use crate::AppState;
 
 #[utoipa::path(
@@ -76,16 +76,15 @@ pub async fn create_entries(
     // encourage them to upgrade before removing this legacy code. Until then,
     // we support both methods.
     // TODO: Remove this legacy handling while every publishers are on the 2.0 version.
-    let signature =
-        match assert_signature_is_valid(&new_entries, &account_address, &public_key, None) {
-            Ok(signature) => signature,
-            Err(_) => {
-                tracing::debug!(
-                    "assert_signature_is_valid failed. Trying again with legacy signature..."
-                );
-                assert_signature_is_valid(&new_entries, &account_address, &public_key, Some(true))?
-            }
-        };
+    let signature = match assert_signature_is_valid(&new_entries, &account_address, &public_key) {
+        Ok(signature) => signature,
+        Err(_) => {
+            tracing::debug!(
+                "assert_signature_is_valid failed. Trying again with legacy signature..."
+            );
+            assert_legacy_signature_is_valid(&new_entries, &account_address, &public_key)?
+        }
+    };
 
     let new_entries_db = new_entries
         .entries

--- a/pragma-node/src/handlers/entries/create_entry.rs
+++ b/pragma-node/src/handlers/entries/create_entry.rs
@@ -8,7 +8,8 @@ use crate::config::config;
 use crate::handlers::entries::{CreateEntryRequest, CreateEntryResponse};
 use crate::infra::kafka;
 use crate::infra::repositories::publisher_repository;
-use crate::utils::{assert_legacy_signature_is_valid, assert_signature_is_valid, JsonExtractor};
+use crate::types::entries::Entry;
+use crate::utils::{assert_request_signature_is_valid, JsonExtractor};
 use crate::AppState;
 
 #[utoipa::path(
@@ -70,21 +71,11 @@ pub async fn create_entries(
         account_address
     );
 
-    // We recently updated our Pragma-SDK. This included a breaking change for how we
-    // sign the entries before publishing them.
-    // We want to support our publishers who are still on the older version and
-    // encourage them to upgrade before removing this legacy code. Until then,
-    // we support both methods.
-    // TODO: Remove this legacy handling while every publishers are on the 2.0 version.
-    let signature = match assert_signature_is_valid(&new_entries, &account_address, &public_key) {
-        Ok(signature) => signature,
-        Err(_) => {
-            tracing::debug!(
-                "assert_signature_is_valid failed. Trying again with legacy signature..."
-            );
-            assert_legacy_signature_is_valid(&new_entries, &account_address, &public_key)?
-        }
-    };
+    let signature = assert_request_signature_is_valid::<CreateEntryRequest, Entry>(
+        &new_entries,
+        &account_address,
+        &public_key,
+    )?;
 
     let new_entries_db = new_entries
         .entries

--- a/pragma-node/src/handlers/entries/create_entry.rs
+++ b/pragma-node/src/handlers/entries/create_entry.rs
@@ -72,14 +72,17 @@ pub async fn create_entries(
         account_address
     );
 
+    // We recently updated our Pragma-SDK. This included a breaking change for how we
+    // sign the entries before publishing them.
+    // We want to support our publishers who are still on the older version and
+    // encourage them to upgrade before removing this legacy code. Until then,
+    // we support both methods.
+    // TODO: Remove this legacy handling while every publishers are on the 2.0 version.
     let published_message = match build_publish_message(&new_entries.entries, None) {
         Ok(message) => message,
         Err(_) => {
             // If the new version fails, try the legacy version
-            match build_publish_message(&new_entries.entries, Some(true)) {
-                Ok(message) => message,
-                Err(err) => panic!("Failed to build publish message: {:?}", err),
-            }
+            build_publish_message(&new_entries.entries, Some(true))?
         }
     };
     let message_hash = published_message.message_hash(account_address);

--- a/pragma-node/src/handlers/entries/create_future_entry.rs
+++ b/pragma-node/src/handlers/entries/create_future_entry.rs
@@ -73,14 +73,17 @@ pub async fn create_future_entries(
         account_address
     );
 
+    // We recently updated our Pragma-SDK. This included a breaking change for how we
+    // sign the entries before publishing them.
+    // We want to support our publishers who are still on the older version and
+    // encourage them to upgrade before removing this legacy code. Until then,
+    // we support both methods.
+    // TODO: Remove this legacy handling while every publishers are on the 2.0 version.
     let published_message = match build_publish_message(&new_entries.entries, None) {
         Ok(message) => message,
         Err(_) => {
             // If the new version fails, try the legacy version
-            match build_publish_message(&new_entries.entries, Some(true)) {
-                Ok(message) => message,
-                Err(err) => panic!("Failed to build publish message: {:?}", err),
-            }
+            build_publish_message(&new_entries.entries, Some(true))?
         }
     };
     let message_hash = published_message.message_hash(account_address);

--- a/pragma-node/src/handlers/entries/create_future_entry.rs
+++ b/pragma-node/src/handlers/entries/create_future_entry.rs
@@ -9,7 +9,8 @@ use super::{CreateFutureEntryRequest, CreateFutureEntryResponse};
 use crate::config::config;
 use crate::infra::kafka;
 use crate::infra::repositories::publisher_repository;
-use crate::utils::{assert_legacy_signature_is_valid, assert_signature_is_valid, JsonExtractor};
+use crate::types::entries::FutureEntry;
+use crate::utils::{assert_request_signature_is_valid, JsonExtractor};
 use crate::AppState;
 
 #[utoipa::path(
@@ -71,21 +72,11 @@ pub async fn create_future_entries(
         account_address
     );
 
-    // We recently updated our Pragma-SDK. This included a breaking change for how we
-    // sign the entries before publishing them.
-    // We want to support our publishers who are still on the older version and
-    // encourage them to upgrade before removing this legacy code. Until then,
-    // we support both methods.
-    // TODO: Remove this legacy handling while every publishers are on the 2.0 version.
-    let signature = match assert_signature_is_valid(&new_entries, &account_address, &public_key) {
-        Ok(signature) => signature,
-        Err(_) => {
-            tracing::debug!(
-                "assert_signature_is_valid failed. Trying again with legacy signature..."
-            );
-            assert_legacy_signature_is_valid(&new_entries, &account_address, &public_key)?
-        }
-    };
+    let signature = assert_request_signature_is_valid::<CreateFutureEntryRequest, FutureEntry>(
+        &new_entries,
+        &account_address,
+        &public_key,
+    )?;
 
     let new_entries_db = new_entries
         .entries

--- a/pragma-node/src/handlers/entries/create_future_entry.rs
+++ b/pragma-node/src/handlers/entries/create_future_entry.rs
@@ -2,16 +2,14 @@ use axum::extract::State;
 use axum::Json;
 use chrono::{DateTime, Utc};
 use pragma_entities::{EntryError, NewFutureEntry, PublisherError};
-use starknet::core::crypto::{ecdsa_verify, Signature};
 use starknet::core::types::FieldElement;
 
 use super::{CreateFutureEntryRequest, CreateFutureEntryResponse};
-use crate::types::entries::build_publish_message;
 
 use crate::config::config;
 use crate::infra::kafka;
 use crate::infra::repositories::publisher_repository;
-use crate::utils::JsonExtractor;
+use crate::utils::{assert_signature_is_valid, JsonExtractor};
 use crate::AppState;
 
 #[utoipa::path(
@@ -79,25 +77,16 @@ pub async fn create_future_entries(
     // encourage them to upgrade before removing this legacy code. Until then,
     // we support both methods.
     // TODO: Remove this legacy handling while every publishers are on the 2.0 version.
-    let published_message = match build_publish_message(&new_entries.entries, None) {
-        Ok(message) => message,
-        Err(_) => {
-            // If the new version fails, try the legacy version
-            build_publish_message(&new_entries.entries, Some(true))?
-        }
-    };
-    let message_hash = published_message.message_hash(account_address);
-    let signature = Signature {
-        r: new_entries.signature[0],
-        s: new_entries.signature[1],
-    };
-
-    if !ecdsa_verify(&public_key, &message_hash, &signature)
-        .map_err(EntryError::InvalidSignature)?
-    {
-        tracing::error!("Invalid signature for message hash {:?}", &message_hash);
-        return Err(EntryError::Unauthorized);
-    }
+    let signature =
+        match assert_signature_is_valid(&new_entries, &account_address, &public_key, None) {
+            Ok(signature) => signature,
+            Err(_) => {
+                tracing::debug!(
+                    "assert_signature_is_valid failed. Trying again with legacy signature..."
+                );
+                assert_signature_is_valid(&new_entries, &account_address, &public_key, Some(true))?
+            }
+        };
 
     let new_entries_db = new_entries
         .entries
@@ -150,10 +139,9 @@ pub async fn create_future_entries(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use rstest::rstest;
 
-    use crate::types::entries::{FutureEntry, PerpEntry};
+    use crate::types::entries::{build_publish_message, FutureEntry, PerpEntry};
 
     #[rstest]
     fn test_build_publish_message_empty() {

--- a/pragma-node/src/handlers/entries/mod.rs
+++ b/pragma-node/src/handlers/entries/mod.rs
@@ -29,10 +29,29 @@ use crate::{
     utils::doc_examples,
 };
 
+pub trait SignedRequest {
+    type EntryType;
+
+    fn signature(&self) -> &Vec<FieldElement>;
+    fn entries(&self) -> &Vec<Self::EntryType>;
+}
+
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct CreateEntryRequest {
-    signature: Vec<FieldElement>,
-    entries: Vec<Entry>,
+    pub signature: Vec<FieldElement>,
+    pub entries: Vec<Entry>,
+}
+
+impl SignedRequest for CreateEntryRequest {
+    type EntryType = Entry;
+
+    fn signature(&self) -> &Vec<FieldElement> {
+        &self.signature
+    }
+
+    fn entries(&self) -> &Vec<Self::EntryType> {
+        &self.entries
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
@@ -42,8 +61,20 @@ pub struct CreateEntryResponse {
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct CreateFutureEntryRequest {
-    signature: Vec<FieldElement>,
-    entries: Vec<FutureEntry>,
+    pub signature: Vec<FieldElement>,
+    pub entries: Vec<FutureEntry>,
+}
+
+impl SignedRequest for CreateFutureEntryRequest {
+    type EntryType = FutureEntry;
+
+    fn signature(&self) -> &Vec<FieldElement> {
+        &self.signature
+    }
+
+    fn entries(&self) -> &Vec<Self::EntryType> {
+        &self.entries
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]

--- a/pragma-node/src/handlers/entries/mod.rs
+++ b/pragma-node/src/handlers/entries/mod.rs
@@ -29,27 +29,20 @@ use crate::{
     utils::doc_examples,
 };
 
-pub trait SignedRequest {
-    type EntryType;
-
-    fn signature(&self) -> &Vec<FieldElement>;
-    fn entries(&self) -> &Vec<Self::EntryType>;
-}
-
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct CreateEntryRequest {
     pub signature: Vec<FieldElement>,
     pub entries: Vec<Entry>,
 }
 
-impl SignedRequest for CreateEntryRequest {
-    type EntryType = Entry;
-
-    fn signature(&self) -> &Vec<FieldElement> {
+impl AsRef<[FieldElement]> for CreateEntryRequest {
+    fn as_ref(&self) -> &[FieldElement] {
         &self.signature
     }
+}
 
-    fn entries(&self) -> &Vec<Self::EntryType> {
+impl AsRef<[Entry]> for CreateEntryRequest {
+    fn as_ref(&self) -> &[Entry] {
         &self.entries
     }
 }
@@ -65,14 +58,14 @@ pub struct CreateFutureEntryRequest {
     pub entries: Vec<FutureEntry>,
 }
 
-impl SignedRequest for CreateFutureEntryRequest {
-    type EntryType = FutureEntry;
-
-    fn signature(&self) -> &Vec<FieldElement> {
+impl AsRef<[FieldElement]> for CreateFutureEntryRequest {
+    fn as_ref(&self) -> &[FieldElement] {
         &self.signature
     }
+}
 
-    fn entries(&self) -> &Vec<Self::EntryType> {
+impl AsRef<[FutureEntry]> for CreateFutureEntryRequest {
+    fn as_ref(&self) -> &[FutureEntry] {
         &self.entries
     }
 }

--- a/pragma-node/src/main.rs
+++ b/pragma-node/src/main.rs
@@ -76,15 +76,14 @@ async fn main() {
 
     // Create the Metrics registry
     let metrics_registry = MetricsRegistry::new();
-    let ws_metrics =
-        Arc::new(WsMetrics::new(&metrics_registry).expect("Failed to create WsMetrics"));
+    let ws_metrics = WsMetrics::new(&metrics_registry).expect("Failed to create WsMetrics");
 
     let state = AppState {
         offchain_pool,
         onchain_pool,
         publishers_updates_cache,
         pragma_signer,
-        ws_metrics,
+        ws_metrics: Arc::new(ws_metrics),
     };
 
     tokio::join!(

--- a/pragma-node/src/types/entries.rs
+++ b/pragma-node/src/types/entries.rs
@@ -156,7 +156,9 @@ where
     let mut raw_message_json = serde_json::json!({
         "domain": {
             "name": "Pragma",
-            "version": "1"
+            "version": "1",
+            "chainId": "1",
+            "revision": "0"
         },
         "primaryType": "Request",
         "message": {
@@ -166,7 +168,9 @@ where
         "types": {
             "StarkNetDomain": [
                 {"name": "name", "type": "felt"},
-                {"name": "version", "type": "felt"}
+                {"name": "version", "type": "felt"},
+                {"name": "chainId", "type": "felt"},
+                {"name": "revision", "type": "felt"}
             ],
             "Request": [
                 {"name": "action", "type": "felt"},

--- a/pragma-node/src/types/entries.rs
+++ b/pragma-node/src/types/entries.rs
@@ -126,6 +126,7 @@ where
 {
     // TODO(akhercha): ugly, refine
     let mut is_future = false;
+    let is_legacy = is_legacy.unwrap_or(false);
 
     // Construct the raw string with placeholders for the entries
     let raw_entries: Vec<_> = entries
@@ -163,7 +164,7 @@ where
     // encourage them to upgrade before removing this legacy code. Until then,
     // we support both methods.
     // TODO: Remove this legacy handling while every publishers are on the 2.0 version.
-    let mut raw_message_json = if is_legacy.unwrap_or(false) {
+    let mut raw_message_json = if is_legacy {
         serde_json::json!({
             "domain": {
                 "name": "Pragma",
@@ -210,7 +211,7 @@ where
                 "entries": raw_entries
             },
             "types": {
-                "StarknetDomain": [
+                "StarkNetDomain": [
                     {"name": "name", "type": "felt"},
                     {"name": "version", "type": "felt"},
                     {"name": "chainId", "type": "felt"},

--- a/pragma-node/src/types/entries.rs
+++ b/pragma-node/src/types/entries.rs
@@ -116,6 +116,7 @@ pub struct PublishMessage<E: EntryTrait + Serialize> {
     pub entries: Vec<E>,
 }
 
+// TODO: Remove this legacy handling while every publishers are on the 2.0 version.
 pub fn build_publish_message<E>(
     entries: &[E],
     is_legacy: Option<bool>,
@@ -156,6 +157,12 @@ where
         })
         .collect::<Vec<_>>();
 
+    // We recently updated our Pragma-SDK. This included a breaking change for how we
+    // sign the entries before publishing them.
+    // We want to support our publishers who are still on the older version and
+    // encourage them to upgrade before removing this legacy code. Until then,
+    // we support both methods.
+    // TODO: Remove this legacy handling while every publishers are on the 2.0 version.
     let mut raw_message_json = if is_legacy.unwrap_or(false) {
         serde_json::json!({
             "domain": {

--- a/pragma-node/src/utils/mod.rs
+++ b/pragma-node/src/utils/mod.rs
@@ -4,7 +4,7 @@ pub use custom_extractors::json_extractor::JsonExtractor;
 pub use custom_extractors::path_extractor::PathExtractor;
 pub use signing::starkex::StarkexPrice;
 pub use signing::typed_data::TypedData;
-pub use signing::{assert_legacy_signature_is_valid, assert_signature_is_valid, sign_data};
+pub use signing::{assert_request_signature_is_valid, sign_data};
 
 use bigdecimal::num_bigint::ToBigInt;
 use bigdecimal::{BigDecimal, ToPrimitive};

--- a/pragma-node/src/utils/mod.rs
+++ b/pragma-node/src/utils/mod.rs
@@ -2,9 +2,9 @@ pub use aws::PragmaSignerBuilder;
 pub use conversion::{convert_via_quote, format_bigdecimal_price, normalize_to_decimals};
 pub use custom_extractors::json_extractor::JsonExtractor;
 pub use custom_extractors::path_extractor::PathExtractor;
-pub use signing::sign_data;
 pub use signing::starkex::StarkexPrice;
 pub use signing::typed_data::TypedData;
+pub use signing::{assert_signature_is_valid, sign_data};
 
 use bigdecimal::num_bigint::ToBigInt;
 use bigdecimal::{BigDecimal, ToPrimitive};

--- a/pragma-node/src/utils/mod.rs
+++ b/pragma-node/src/utils/mod.rs
@@ -4,7 +4,7 @@ pub use custom_extractors::json_extractor::JsonExtractor;
 pub use custom_extractors::path_extractor::PathExtractor;
 pub use signing::starkex::StarkexPrice;
 pub use signing::typed_data::TypedData;
-pub use signing::{assert_signature_is_valid, sign_data};
+pub use signing::{assert_legacy_signature_is_valid, assert_signature_is_valid, sign_data};
 
 use bigdecimal::num_bigint::ToBigInt;
 use bigdecimal::{BigDecimal, ToPrimitive};

--- a/pragma-node/src/utils/signing/mock/typed_data_example.json
+++ b/pragma-node/src/utils/signing/mock/typed_data_example.json
@@ -3,7 +3,8 @@
     "StarkNetDomain": [
       { "name": "name", "type": "felt" },
       { "name": "version", "type": "felt" },
-      { "name": "chainId", "type": "felt" }
+      { "name": "chainId", "type": "felt" },
+      { "name": "revision", "type": "felt" }
     ],
     "Person": [
       { "name": "name", "type": "felt" },
@@ -19,7 +20,8 @@
   "domain": {
     "name": "StarkNet Mail",
     "version": "1",
-    "chainId": 1
+    "chainId": "1",
+    "revision": "0"
   },
   "message": {
     "from": {

--- a/pragma-node/src/utils/signing/mock/typed_data_felt_array_example.json
+++ b/pragma-node/src/utils/signing/mock/typed_data_felt_array_example.json
@@ -3,7 +3,8 @@
     "StarkNetDomain": [
       { "name": "name", "type": "felt" },
       { "name": "version", "type": "felt" },
-      { "name": "chainId", "type": "felt" }
+      { "name": "chainId", "type": "felt" },
+      { "name": "revision", "type": "felt" }
     ],
     "Person": [
       { "name": "name", "type": "felt" },
@@ -20,7 +21,8 @@
   "domain": {
     "name": "StarkNet Mail",
     "version": "1",
-    "chainId": 1
+    "chainId": "1",
+    "revision": "0"
   },
   "message": {
     "from": {

--- a/pragma-node/src/utils/signing/mock/typed_data_long_string_example.json
+++ b/pragma-node/src/utils/signing/mock/typed_data_long_string_example.json
@@ -3,7 +3,8 @@
     "StarkNetDomain": [
       { "name": "name", "type": "felt" },
       { "name": "version", "type": "felt" },
-      { "name": "chainId", "type": "felt" }
+      { "name": "chainId", "type": "felt" },
+      { "name": "revision", "type": "felt" }
     ],
     "Person": [
       { "name": "name", "type": "felt" },
@@ -23,7 +24,8 @@
   "domain": {
     "name": "StarkNet Mail",
     "version": "1",
-    "chainId": 1
+    "chainId": "1",
+    "revision": "0"
   },
   "message": {
     "from": {

--- a/pragma-node/src/utils/signing/mock/typed_data_struct_array_example.json
+++ b/pragma-node/src/utils/signing/mock/typed_data_struct_array_example.json
@@ -3,7 +3,8 @@
     "StarkNetDomain": [
       { "name": "name", "type": "felt" },
       { "name": "version", "type": "felt" },
-      { "name": "chainId", "type": "felt" }
+      { "name": "chainId", "type": "felt" },
+      { "name": "revision", "type": "felt" }
     ],
     "Person": [
       { "name": "name", "type": "felt" },
@@ -24,7 +25,8 @@
   "domain": {
     "name": "StarkNet Mail",
     "version": "1",
-    "chainId": 1
+    "chainId": "1",
+    "revision": "0"
   },
   "message": {
     "from": {

--- a/pragma-node/src/utils/signing/mod.rs
+++ b/pragma-node/src/utils/signing/mod.rs
@@ -50,7 +50,6 @@ pub fn assert_signature_is_valid<T>(
 ) -> Result<Signature, EntryError>
 where
     T: SignedRequest,
-    <T as SignedRequest>::EntryType: EntryTrait,
     for<'de> <T as SignedRequest>::EntryType: EntryTrait + Serialize + Deserialize<'de>,
 {
     let published_message = build_publish_message(request.entries(), is_legacy)?;

--- a/pragma-node/src/utils/signing/mod.rs
+++ b/pragma-node/src/utils/signing/mod.rs
@@ -43,19 +43,43 @@ pub fn sign_data(signer: &SigningKey, data: &impl Signable) -> Result<String, Si
 
 /// Assert that a signature (passed with the request for creating new
 /// entries) is correctly signed by the publisher and in a valid format.
-/// NOTE: the [is_legacy] parameter can be set to True for signatures
-/// that uses our SDK before version 2.0.
 pub fn assert_signature_is_valid<T>(
     request: &T,
     account_address: &FieldElement,
     public_key: &FieldElement,
-    is_legacy: Option<bool>,
 ) -> Result<Signature, EntryError>
 where
     T: SignedRequest,
     for<'de> <T as SignedRequest>::EntryType: EntryTrait + Serialize + Deserialize<'de>,
 {
-    let published_message = build_publish_message(request.entries(), is_legacy)?;
+    let published_message = build_publish_message(request.entries(), None)?;
+    let message_hash = published_message.message_hash(*account_address);
+
+    let signature_request = request.signature();
+    let signature = Signature {
+        r: signature_request[0],
+        s: signature_request[1],
+    };
+    if !ecdsa_verify(public_key, &message_hash, &signature).map_err(EntryError::InvalidSignature)? {
+        return Err(EntryError::Unauthorized);
+    }
+    Ok(signature)
+}
+
+/// Assert that a signature (passed with the request for creating new
+/// entries) is correctly signed by the publisher and in a valid format.
+/// NOTE: Used for legacy signatures that uses our SDK before version 2.0.
+/// TODO: Remove this function when we stop supporting the old format
+pub fn assert_legacy_signature_is_valid<T>(
+    request: &T,
+    account_address: &FieldElement,
+    public_key: &FieldElement,
+) -> Result<Signature, EntryError>
+where
+    T: SignedRequest,
+    for<'de> <T as SignedRequest>::EntryType: EntryTrait + Serialize + Deserialize<'de>,
+{
+    let published_message = build_publish_message(request.entries(), Some(true))?;
     let message_hash = published_message.message_hash(*account_address);
 
     let signature_request = request.signature();

--- a/pragma-node/src/utils/signing/mod.rs
+++ b/pragma-node/src/utils/signing/mod.rs
@@ -2,11 +2,21 @@ pub mod starkex;
 pub mod typed_data;
 
 use pragma_common::types::ConversionError;
+use pragma_entities::EntryError;
+use serde::{Deserialize, Serialize};
 use starknet::{
-    core::{crypto::EcdsaSignError, types::FieldElement},
+    core::{
+        crypto::{ecdsa_verify, EcdsaSignError, Signature},
+        types::FieldElement,
+    },
     signers::SigningKey,
 };
 use thiserror::Error;
+
+use crate::{
+    handlers::entries::SignedRequest,
+    types::entries::{build_publish_message, EntryTrait},
+};
 
 #[derive(Debug, Error)]
 pub enum SigningError {
@@ -29,4 +39,30 @@ pub fn sign_data(signer: &SigningKey, data: &impl Signable) -> Result<String, Si
         .sign(&hash_to_sign)
         .map_err(SigningError::SigningError)?;
     Ok(format!("0x{:}", signature))
+}
+
+/// Assert that a Signature is correct
+pub fn assert_signature_is_valid<T>(
+    request: &T,
+    account_address: &FieldElement,
+    public_key: &FieldElement,
+    is_legacy: Option<bool>,
+) -> Result<Signature, EntryError>
+where
+    T: SignedRequest,
+    <T as SignedRequest>::EntryType: EntryTrait,
+    for<'de> <T as SignedRequest>::EntryType: EntryTrait + Serialize + Deserialize<'de>,
+{
+    let published_message = build_publish_message(request.entries(), is_legacy)?;
+    let message_hash = published_message.message_hash(*account_address);
+
+    let signature_request = request.signature();
+    let signature = Signature {
+        r: signature_request[0],
+        s: signature_request[1],
+    };
+    if !ecdsa_verify(public_key, &message_hash, &signature).map_err(EntryError::InvalidSignature)? {
+        return Err(EntryError::Unauthorized);
+    }
+    Ok(signature)
 }

--- a/pragma-node/src/utils/signing/mod.rs
+++ b/pragma-node/src/utils/signing/mod.rs
@@ -41,7 +41,10 @@ pub fn sign_data(signer: &SigningKey, data: &impl Signable) -> Result<String, Si
     Ok(format!("0x{:}", signature))
 }
 
-/// Assert that a Signature is correct
+/// Assert that a signature (passed with the request for creating new
+/// entries) is correctly signed by the publisher and in a valid format.
+/// NOTE: the [is_legacy] parameter can be set to True for signatures
+/// that uses our SDK before version 2.0.
 pub fn assert_signature_is_valid<T>(
     request: &T,
     account_address: &FieldElement,

--- a/pragma-node/src/utils/signing/mod.rs
+++ b/pragma-node/src/utils/signing/mod.rs
@@ -13,10 +13,7 @@ use starknet::{
 };
 use thiserror::Error;
 
-use crate::{
-    handlers::entries::SignedRequest,
-    types::entries::{build_publish_message, EntryTrait},
-};
+use crate::types::entries::{build_publish_message, EntryTrait};
 
 #[derive(Debug, Error)]
 pub enum SigningError {
@@ -41,53 +38,99 @@ pub fn sign_data(signer: &SigningKey, data: &impl Signable) -> Result<String, Si
     Ok(format!("0x{:}", signature))
 }
 
-/// Assert that a signature (passed with the request for creating new
+/// Assert that a new entries request is correctly signed
+/// by the publisher.
+/// If it is, we return the signature.
+pub fn assert_request_signature_is_valid<R, E>(
+    new_entries_request: &R,
+    publisher_account: &FieldElement,
+    publisher_public_key: &FieldElement,
+) -> Result<Signature, EntryError>
+where
+    R: AsRef<[FieldElement]> + AsRef<[E]>,
+    E: EntryTrait + Serialize + for<'de> Deserialize<'de>,
+{
+    // We recently updated our Pragma-SDK. This included a breaking change for how we
+    // sign the entries before publishing them.
+    // We want to support our publishers who are still on the older version and
+    // encourage them to upgrade before removing this legacy code. Until then,
+    // we support both methods.
+    // TODO: Remove this legacy handling while every publishers are on the 2.0 version.
+    let signature = match assert_signature_is_valid::<R, E>(
+        new_entries_request,
+        publisher_account,
+        publisher_public_key,
+    ) {
+        Ok(signature) => signature,
+        Err(_) => {
+            tracing::debug!(
+                "assert_signature_is_valid failed. Trying again with legacy signature..."
+            );
+            assert_legacy_signature_is_valid::<R, E>(
+                new_entries_request,
+                publisher_account,
+                publisher_public_key,
+            )?
+        }
+    };
+    Ok(signature)
+}
+
+/// Assert that a request (passed with the request for creating new
 /// entries) is correctly signed by the publisher and in a valid format.
-pub fn assert_signature_is_valid<T>(
-    request: &T,
+/// Returns the signature if it is correct.
+fn assert_signature_is_valid<R, E>(
+    new_entries_request: &R,
     account_address: &FieldElement,
     public_key: &FieldElement,
 ) -> Result<Signature, EntryError>
 where
-    T: SignedRequest,
-    for<'de> <T as SignedRequest>::EntryType: EntryTrait + Serialize + Deserialize<'de>,
+    R: AsRef<[FieldElement]> + AsRef<[E]>,
+    E: EntryTrait + Serialize + for<'de> Deserialize<'de>,
 {
-    let published_message = build_publish_message(request.entries(), None)?;
+    let entries: &[E] = new_entries_request.as_ref();
+    let published_message = build_publish_message(entries, None)?;
     let message_hash = published_message.message_hash(*account_address);
 
-    let signature_request = request.signature();
+    let signature_slice: &[FieldElement] = new_entries_request.as_ref();
     let signature = Signature {
-        r: signature_request[0],
-        s: signature_request[1],
+        r: signature_slice[0],
+        s: signature_slice[1],
     };
+
     if !ecdsa_verify(public_key, &message_hash, &signature).map_err(EntryError::InvalidSignature)? {
+        tracing::error!("Invalid signature for message hash {:?}", &message_hash);
         return Err(EntryError::Unauthorized);
     }
     Ok(signature)
 }
 
-/// Assert that a signature (passed with the request for creating new
+/// Assert that a legacy request (passed with the request for creating new
 /// entries) is correctly signed by the publisher and in a valid format.
+/// Returns the signature if it is correct.
 /// NOTE: Used for legacy signatures that uses our SDK before version 2.0.
 /// TODO: Remove this function when we stop supporting the old format
-pub fn assert_legacy_signature_is_valid<T>(
-    request: &T,
+fn assert_legacy_signature_is_valid<R, E>(
+    new_entries_request: &R,
     account_address: &FieldElement,
     public_key: &FieldElement,
 ) -> Result<Signature, EntryError>
 where
-    T: SignedRequest,
-    for<'de> <T as SignedRequest>::EntryType: EntryTrait + Serialize + Deserialize<'de>,
+    R: AsRef<[FieldElement]> + AsRef<[E]>,
+    E: EntryTrait + Serialize + for<'de> Deserialize<'de>,
 {
-    let published_message = build_publish_message(request.entries(), Some(true))?;
+    let entries: &[E] = new_entries_request.as_ref();
+    let published_message = build_publish_message(entries, None)?;
     let message_hash = published_message.message_hash(*account_address);
 
-    let signature_request = request.signature();
+    let signature_slice: &[FieldElement] = new_entries_request.as_ref();
     let signature = Signature {
-        r: signature_request[0],
-        s: signature_request[1],
+        r: signature_slice[0],
+        s: signature_slice[1],
     };
+
     if !ecdsa_verify(public_key, &message_hash, &signature).map_err(EntryError::InvalidSignature)? {
+        tracing::error!("Invalid signature for message hash {:?}", &message_hash);
         return Err(EntryError::Unauthorized);
     }
     Ok(signature)

--- a/pragma-node/src/utils/signing/mod.rs
+++ b/pragma-node/src/utils/signing/mod.rs
@@ -99,8 +99,10 @@ where
     };
 
     if !ecdsa_verify(public_key, &message_hash, &signature).map_err(EntryError::InvalidSignature)? {
-        tracing::error!("Invalid signature for message hash {:?}", &message_hash);
-        return Err(EntryError::Unauthorized);
+        return Err(EntryError::Unauthorized(format!(
+            "Invalid signature for message hash {:?}",
+            &message_hash
+        )));
     }
     Ok(signature)
 }
@@ -130,8 +132,10 @@ where
     };
 
     if !ecdsa_verify(public_key, &message_hash, &signature).map_err(EntryError::InvalidSignature)? {
-        tracing::error!("Invalid signature for message hash {:?}", &message_hash);
-        return Err(EntryError::Unauthorized);
+        return Err(EntryError::Unauthorized(format!(
+            "Invalid signature for message hash {:?}",
+            &message_hash
+        )));
     }
     Ok(signature)
 }

--- a/pragma-node/src/utils/signing/mod.rs
+++ b/pragma-node/src/utils/signing/mod.rs
@@ -120,7 +120,7 @@ where
     E: EntryTrait + Serialize + for<'de> Deserialize<'de>,
 {
     let entries: &[E] = new_entries_request.as_ref();
-    let published_message = build_publish_message(entries, None)?;
+    let published_message = build_publish_message(entries, Some(true))?;
     let message_hash = published_message.message_hash(*account_address);
 
     let signature_slice: &[FieldElement] = new_entries_request.as_ref();

--- a/pragma-node/src/utils/signing/typed_data.rs
+++ b/pragma-node/src/utils/signing/typed_data.rs
@@ -14,7 +14,9 @@ use std::{
 pub struct StarkNetDomain {
     pub name: Option<String>,
     pub version: Option<String>,
-    pub chain_id: Option<Value>, // Using Value to represent either String or Number
+    #[serde(rename = "chainId")]
+    pub chain_id: Option<String>,
+    pub revision: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -30,7 +32,8 @@ pub struct DomainType {
     pub name: String,
     pub version: String,
     #[serde(rename = "chainId")]
-    pub chain_id: Option<u64>,
+    pub chain_id: String,
+    pub revision: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/pragma-node/src/utils/signing/typed_data.rs
+++ b/pragma-node/src/utils/signing/typed_data.rs
@@ -585,8 +585,8 @@ mod tests {
     )]
     #[case(
         TD_FELT_ARR,
-        "0x22d46b6e8e12c06cbce8828cec76e8f6416e54bda8bf77ac0bd64c242e423bb",
-        "0x89b087967a494d99895ca3800a580700d7f277f30ae8d26d671fa4864bf294"
+        "0xcd2a3d9f938e13cd947ec05abc7fe734df8dd826",
+        "0x22d46b6e8e12c06cbce8828cec76e8f6416e54bda8bf77ac0bd64c242e423bb"
     )]
     #[case(
         TD_STRUCT_ARR,

--- a/pragma-node/src/utils/signing/typed_data.rs
+++ b/pragma-node/src/utils/signing/typed_data.rs
@@ -445,7 +445,7 @@ mod tests {
     #[case(
         TD,
         "StarkNetDomain",
-        "0x1bfc207425a47a5dfa1a50a4f5241203f50624ca5fdf5e18755765416b8e288"
+        "0x25b2a6be3b4f788a40d183c71287277bf6cc227fc52398ad813b8d79fb711af"
     )]
     #[case(
         TD,
@@ -520,7 +520,7 @@ mod tests {
         let result = typed_data.struct_hash("StarkNetDomain", &json_map);
         assert_eq!(
             format!("{:#x}", result),
-            "0x54833b121883a3e3aebff48ec08a962f5742e5f7b973469c1f8f4f55d470b07"
+            "0x791677d28015bfb506ef968e44b486659cdd6306095da0a259336151130a78c"
         );
     }
 
@@ -576,22 +576,22 @@ mod tests {
     #[case(
         TD,
         "0xcd2a3d9f938e13cd947ec05abc7fe734df8dd826",
-        "0x6fcff244f63e38b9d88b9e3378d44757710d1b244282b435cb472053c8d78d0"
+        "0x2c3252719b4b7fb49b96f68ea62d64f6be54562826e93a978250fd99155bccd"
     )]
     #[case(
         TD_STRING,
         "0xcd2a3d9f938e13cd947ec05abc7fe734df8dd826",
-        "0x691b977ee0ee645647336f01d724274731f544ad0d626b078033d2541ee641d"
+        "0x7b2cac6cf11869d9a72e2492f270be9d09d5b87c92a74162fa9ce3d74a4b78c"
     )]
     #[case(
         TD_FELT_ARR,
-        "0xcd2a3d9f938e13cd947ec05abc7fe734df8dd826",
-        "0x30ab43ef724b08c3b0a9bbe425e47c6173470be75d1d4c55fd5bf9309896bce"
+        "0x22d46b6e8e12c06cbce8828cec76e8f6416e54bda8bf77ac0bd64c242e423bb",
+        "0x89b087967a494d99895ca3800a580700d7f277f30ae8d26d671fa4864bf294"
     )]
     #[case(
         TD_STRUCT_ARR,
         "0xcd2a3d9f938e13cd947ec05abc7fe734df8dd826",
-        "0x5914ed2764eca2e6a41eb037feefd3d2e33d9af6225a9e7fe31ac943ff712c"
+        "0x243a96015b473247fd3fb82a30aee0a036edc95017ba85a17029e1afbf3c92d"
     )]
     fn test_message_hash(
         #[case] example: &str,

--- a/pragma-node/src/utils/signing/typed_data.rs
+++ b/pragma-node/src/utils/signing/typed_data.rs
@@ -32,8 +32,8 @@ pub struct DomainType {
     pub name: String,
     pub version: String,
     #[serde(rename = "chainId")]
-    pub chain_id: String,
-    pub revision: String,
+    pub chain_id: Option<String>,
+    pub revision: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]


### PR DESCRIPTION
Linked to:
https://github.com/astraly-labs/pragma-sdk/issues/155

## Work done

Following the `starknet.py` version bump, the way to use `TypedData` has slightly change and requires now two new fields (mandatory). They've been added so the offchain publishing works correctly (tested locally & it works ✅).

Currently, the function has a `is_legacy` argument for messages still signed the old way. We want to support that for 1-2 months than delete it.