### PR TITLE
feat: add variations to onchain data

### DIFF
--- a/pragma-common/src/types.rs
+++ b/pragma-common/src/types.rs
@@ -42,7 +42,7 @@ pub enum DataType {
 }
 
 // Supported Aggregation Intervals
-#[derive(Default, Debug, Serialize, Deserialize, ToSchema, Clone, Copy)]
+#[derive(Default, Debug, Serialize, Deserialize, ToSchema, Clone, Copy, Eq, PartialEq, Hash)]
 pub enum Interval {
     #[serde(rename = "1min")]
     #[default]

--- a/pragma-node/src/handlers/entries/mod.rs
+++ b/pragma-node/src/handlers/entries/mod.rs
@@ -8,6 +8,8 @@ pub mod get_onchain;
 pub mod get_volatility;
 pub mod subscribe_to_entry;
 
+use std::collections::HashMap;
+
 pub use create_entry::create_entries;
 pub use create_future_entry::create_future_entries;
 pub use get_entry::get_entry;
@@ -110,6 +112,7 @@ pub struct GetOnchainResponse {
     nb_sources_aggregated: u32,
     asset_type: String,
     components: Vec<OnchainEntry>,
+    variations: HashMap<Interval, f32>,
 }
 
 #[derive(Debug, Deserialize, IntoParams, ToSchema)]


### PR DESCRIPTION
## Changes
- Adds a new `variations` field to the `/onchain/x/y` endpoint which returns the 1hour/1day/1week variations.