### PR TITLE
fix: Offchain entry timestamp

### DIFF
--- a/pragma-entities/src/models/entries/entry.rs
+++ b/pragma-entities/src/models/entries/entry.rs
@@ -5,8 +5,8 @@ use bigdecimal::BigDecimal;
 use diesel::internal::derives::multiconnection::chrono::NaiveDateTime;
 use diesel::upsert::excluded;
 use diesel::{
-    AsChangeset, ExpressionMethods, Insertable, PgConnection, PgTextExpressionMethods, QueryDsl,
-    Queryable, RunQueryDsl, Selectable, SelectableHelper,
+    AsChangeset, ExpressionMethods, Insertable, OptionalExtension, PgConnection,
+    PgTextExpressionMethods, QueryDsl, Queryable, RunQueryDsl, Selectable, SelectableHelper,
 };
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -100,5 +100,17 @@ impl Entry {
             .select(entries::pair_id)
             .distinct()
             .load::<String>(conn)
+    }
+
+    pub fn get_last_updated_timestamp(
+        conn: &mut PgConnection,
+        pair: String,
+    ) -> DieselResult<Option<chrono::NaiveDateTime>> {
+        entries::table
+            .filter(entries::pair_id.eq(pair))
+            .select(entries::timestamp)
+            .order(entries::timestamp.desc())
+            .first(conn)
+            .optional()
     }
 }

--- a/pragma-node/src/infra/repositories/entry_repository.rs
+++ b/pragma-node/src/infra/repositories/entry_repository.rs
@@ -489,6 +489,17 @@ pub async fn get_decimals(
     Ok(decimals)
 }
 
+pub async fn get_last_updated_timestamp(
+    pool: &deadpool_diesel::postgres::Pool,
+    pair_id: String,
+) -> Result<Option<NaiveDateTime>, InfraError> {
+    let conn = pool.get().await.map_err(adapt_infra_error)?;
+    conn.interact(|conn| Entry::get_last_updated_timestamp(conn, pair_id))
+        .await
+        .map_err(adapt_infra_error)?
+        .map_err(adapt_infra_error)
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable)]
 pub struct OHLCEntry {
     pub time: NaiveDateTime,


### PR DESCRIPTION
Resolves: #NA

## Updated
- Our offchain entry aggregation returns now the latest timestamp that a source had an entry published.