### PR TITLE
docs: fix invalid link README.md

### DIFF
--- a/pragma-common/README.md
+++ b/pragma-common/README.md
@@ -2,5 +2,5 @@
 
 Common utilities and types used in Pragma rust libraries.
 
-This includes a simple [Merkle Tree implementation](./types/merkle_tree.rs) used
+This includes a simple [Merkle Tree implementation](./src/types/merkle_tree.rs) used
 in Merkle Feeds.


### PR DESCRIPTION
"Merkle Tree implementation" (./types/merkle_tree.rs) link is invalid. Corrected to (./src/types/merkle_tree.rs).