### PR TITLE
fix: starkex integration fixes

### DIFF
--- a/pragma-common/src/types/mod.rs
+++ b/pragma-common/src/types/mod.rs
@@ -27,7 +27,7 @@ pub enum Network {
     Mainnet,
 }
 
-#[derive(Default, Debug, Deserialize, ToSchema, Clone, Copy)]
+#[derive(Default, Debug, Deserialize, ToSchema, Clone, Copy, PartialEq)]
 pub enum DataType {
     #[serde(rename = "spot_entry")]
     #[default]

--- a/pragma-node/examples/starkex.rs
+++ b/pragma-node/examples/starkex.rs
@@ -18,7 +18,7 @@ use tokio_tungstenite::{connect_async, tungstenite::protocol::Message};
 use url::Url;
 
 const TEST_PAIRS: &[&str] = &[
-    "BTC/USD",
+    "EUR/USD",
     // "ETH/USD",
     // "SOL/USD",
     // "AVAX/USD",

--- a/pragma-node/src/handlers/subscribe_to_entry.rs
+++ b/pragma-node/src/handlers/subscribe_to_entry.rs
@@ -6,6 +6,7 @@ use axum::extract::ws::{WebSocket, WebSocketUpgrade};
 use axum::extract::{ConnectInfo, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
+use bigdecimal::BigDecimal;
 use serde::{Deserialize, Serialize};
 
 use pragma_common::types::DataType;
@@ -207,21 +208,25 @@ impl WsEntriesHandler {
             .ok_or(EntryError::InternalServerError)?;
 
         for entry in median_entries {
-            let median_price = entry.median_price.clone();
             let pair_id = entry.pair_id.clone();
-            let mut oracle_price: AssetOraclePrice = entry
-                .try_into()
-                .map_err(|_| EntryError::InternalServerError)?;
+            // Scale price from 8 decimals to 18 decimals for StarkEx
+            // TODO: dont hardcode the decimals, deduce it from the currency decimals
+            let price_with_18_decimals =
+                entry.median_price.clone() * BigDecimal::from(10_u64.pow(10));
 
             let starkex_price = StarkexPrice {
                 oracle_name: PRAGMA_ORACLE_NAME_FOR_STARKEX.to_string(),
                 pair_id: pair_id.clone(),
                 timestamp: now as u64,
-                price: median_price,
+                price: price_with_18_decimals.clone(),
             };
             let signature =
                 sign_data(pragma_signer, &starkex_price).map_err(|_| EntryError::InvalidSigner)?;
 
+            // Create AssetOraclePrice with the original entry (it will be scaled in the TryFrom implementation)
+            let mut oracle_price: AssetOraclePrice = entry
+                .try_into()
+                .map_err(|_| EntryError::InternalServerError)?;
             oracle_price.signature = signature;
             response.oracle_prices.push(oracle_price);
         }

--- a/pragma-node/src/handlers/subscribe_to_entry.rs
+++ b/pragma-node/src/handlers/subscribe_to_entry.rs
@@ -270,8 +270,20 @@ impl WsEntriesHandler {
 
         let mut median_entries = vec![];
         median_entries.extend(index_entries.unwrap_or_default());
-        median_entries.extend(usd_mark_entries.unwrap_or_default());
-        median_entries.extend(non_usd_mark_entries.unwrap_or_default());
+
+        // Add :MARK suffix to mark prices
+        let mut usd_mark_entries = usd_mark_entries.unwrap_or_default();
+        for entry in &mut usd_mark_entries {
+            entry.pair_id = format!("{}:MARK", entry.pair_id);
+        }
+        median_entries.extend(usd_mark_entries);
+
+        let mut non_usd_mark_entries = non_usd_mark_entries.unwrap_or_default();
+        for entry in &mut non_usd_mark_entries {
+            entry.pair_id = format!("{}:MARK", entry.pair_id);
+        }
+        median_entries.extend(non_usd_mark_entries);
+
         Ok(median_entries)
     }
 }

--- a/pragma-node/src/infra/repositories/entry_repository.rs
+++ b/pragma-node/src/infra/repositories/entry_repository.rs
@@ -687,9 +687,13 @@ impl TryFrom<EntryComponent> for SignedPublisherPrice {
 
     fn try_from(component: EntryComponent) -> Result<Self, Self::Error> {
         let asset_id = StarkexPrice::get_oracle_asset_id(&component.publisher, &component.pair_id)?;
+
+        // Scale price from 8 decimals to 18 decimals for StarkEx
+        let price_with_18_decimals = component.price * BigDecimal::from(10_u64.pow(10));
+
         Ok(SignedPublisherPrice {
             oracle_asset_id: format!("0x{}", asset_id),
-            oracle_price: component.price.to_string(),
+            oracle_price: price_with_18_decimals.to_string(),
             timestamp: component.timestamp.to_string(),
             signing_key: component.publisher_address,
             signature: component.publisher_signature,
@@ -716,9 +720,12 @@ impl TryFrom<MedianEntryWithComponents> for AssetOraclePrice {
 
         let global_asset_id = StarkexPrice::get_global_asset_id(&median_entry.pair_id)?;
 
+        // Scale price from 8 decimals to 18 decimals for StarkEx
+        let price_with_18_decimals = median_entry.median_price * BigDecimal::from(10_u64.pow(10));
+
         Ok(AssetOraclePrice {
             global_asset_id,
-            median_price: median_entry.median_price.to_string(),
+            median_price: price_with_18_decimals.to_string(),
             signed_prices: signed_prices?,
             signature: Default::default(),
         })
@@ -898,7 +905,7 @@ pub async fn get_current_median_entries_with_components(
                     entry.pair_id = format!("{}:MARK", entry.pair_id);
                 }
             }
-            
+
             // Keep track of the valid entries we've found
             last_valid_entries = valid_entries;
 

--- a/pragma-node/src/infra/repositories/entry_repository.rs
+++ b/pragma-node/src/infra/repositories/entry_repository.rs
@@ -898,14 +898,7 @@ pub async fn get_current_median_entries_with_components(
             .map_err(adapt_infra_error)?
             .map_err(adapt_infra_error)?;
 
-        if let Some(mut valid_entries) = get_median_entries_response(raw_median_entries) {
-            // Add :MARK suffix to perp entries
-            if entry_type == DataType::PerpEntry {
-                for entry in &mut valid_entries {
-                    entry.pair_id = format!("{}:MARK", entry.pair_id);
-                }
-            }
-
+        if let Some(valid_entries) = get_median_entries_response(raw_median_entries) {
             // Keep track of the valid entries we've found
             last_valid_entries = valid_entries;
 


### PR DESCRIPTION
## Changes

Following Extended integration, we are applying a few changes
- Add back the `:MARK` suffix in the response for mark prices
- Scale prices to 18 decimals before signing following [docs](https://docs.starkware.co/starkex/perpetual/shared/asset_quantities_in_starkex.html#calculating_starkex_internal_prices) requirements