### PR TITLE
feat: introduce Pair type for improved pair handling

### DIFF
--- a/pragma-common/src/types/mod.rs
+++ b/pragma-common/src/types/mod.rs
@@ -4,6 +4,7 @@ pub mod entries;
 pub mod hex_hash;
 pub mod merkle_tree;
 pub mod options;
+pub mod pair;
 pub mod timestamp;
 pub mod typed_data;
 pub mod utils;

--- a/pragma-common/src/types/pair.rs
+++ b/pragma-common/src/types/pair.rs
@@ -1,0 +1,202 @@
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+/// A pair of assets, e.g. BTC/USD
+///
+/// This is a simple struct that holds the base and quote assets.
+/// It is used to represent a pair of assets in the system.
+/// Base and quote are always in UPPERCASE.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
+pub struct Pair {
+    pub base: String,
+    pub quote: String,
+}
+
+impl Pair {
+    /// Creates a routed pair from two pairs that share a common quote currency.
+    ///
+    /// e.g. "BTC/USD" and "ETH/USD" -> "BTC/ETH"
+    pub fn create_routed_pair(base_pair: &Pair, quote_pair: &Pair) -> Self {
+        Self {
+            base: base_pair.base.clone(),
+            quote: quote_pair.base.clone(),
+        }
+    }
+
+    /// Creates a new pair from base and quote currencies.
+    pub fn from_currencies(base: &str, quote: &str) -> Self {
+        Self {
+            base: base.to_uppercase(),
+            quote: quote.to_uppercase(),
+        }
+    }
+
+    /// Get the base and quote as a tuple
+    pub fn as_tuple(&self) -> (String, String) {
+        (self.base.clone(), self.quote.clone())
+    }
+
+    /// Format pair with a custom separator
+    pub fn format_with_separator(&self, separator: &str) -> String {
+        format!("{}{}{}", self.base, separator, self.quote)
+    }
+
+    /// Get the pair ID in standard format without consuming self
+    pub fn to_pair_id(&self) -> String {
+        self.format_with_separator("/")
+    }
+}
+
+impl std::fmt::Display for Pair {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}/{}", self.base, self.quote)
+    }
+}
+
+impl From<Pair> for String {
+    fn from(pair: Pair) -> Self {
+        format!("{0}/{1}", pair.base, pair.quote)
+    }
+}
+
+impl From<&str> for Pair {
+    fn from(pair_id: &str) -> Self {
+        let normalized = pair_id.replace(['-', '_'], "/");
+        let parts: Vec<&str> = normalized.split('/').collect();
+        Self {
+            base: parts[0].trim().to_uppercase(),
+            quote: parts[1].trim().to_uppercase(),
+        }
+    }
+}
+
+impl From<String> for Pair {
+    fn from(pair_id: String) -> Self {
+        Self::from(pair_id.as_str())
+    }
+}
+
+impl From<(String, String)> for Pair {
+    fn from(pair: (String, String)) -> Self {
+        Self {
+            base: pair.0.to_uppercase(),
+            quote: pair.1.to_uppercase(),
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! generate_pair {
+    ($pair_str:expr) => {{
+        #[allow(dead_code)]
+        const fn validate_pair(s: &str) -> bool {
+            let mut count = 0;
+            let chars = s.as_bytes();
+            let mut i = 0;
+            while i < chars.len() {
+                if chars[i] == b'/' || chars[i] == b'-' || chars[i] == b'_' {
+                    count += 1;
+                }
+                i += 1;
+            }
+            count == 1
+        }
+        const _: () = {
+            assert!(
+                validate_pair($pair_str),
+                "Invalid pair format. Expected format: BASE/QUOTE, BASE-QUOTE, or BASE_QUOTE"
+            );
+        };
+        let normalized = $pair_str.replace('-', "/").replace('_', "/");
+        let parts: Vec<&str> = normalized.split('/').collect();
+        Pair {
+            base: parts[0].trim().to_uppercase(),
+            quote: parts[1].trim().to_uppercase(),
+        }
+    }};
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_generate_pair_macro() {
+        let pair1 = generate_pair!("BTC/USD");
+        assert_eq!(pair1.base, "BTC");
+        assert_eq!(pair1.quote, "USD");
+
+        let pair2 = generate_pair!("btc-usd");
+        assert_eq!(pair2.base, "BTC");
+        assert_eq!(pair2.quote, "USD");
+
+        let pair3 = generate_pair!("eth_usdt");
+        assert_eq!(pair3.base, "ETH");
+        assert_eq!(pair3.quote, "USDT");
+
+        let pair4 = generate_pair!("SOL/usdc");
+        assert_eq!(pair4.base, "SOL");
+        assert_eq!(pair4.quote, "USDC");
+
+        let pair5 = generate_pair!("bTc/uSDt");
+        assert_eq!(pair5.base, "BTC");
+        assert_eq!(pair5.quote, "USDT");
+    }
+
+    #[test]
+    fn test_pair_conversions() {
+        // Test from_currencies
+        let pair = Pair::from_currencies("btc", "usd");
+        assert_eq!(pair.base, "BTC");
+        assert_eq!(pair.quote, "USD");
+
+        // Test create_routed_pair
+        let btc_usd = Pair::from_currencies("btc", "usd");
+        let eth_usd = Pair::from_currencies("eth", "usd");
+        let btc_eth = Pair::create_routed_pair(&btc_usd, &eth_usd);
+        assert_eq!(btc_eth.base, "BTC");
+        assert_eq!(btc_eth.quote, "ETH");
+
+        // Test From<&str>
+        let pair_from_str = Pair::from("btc-usd");
+        assert_eq!(pair_from_str.base, "BTC");
+        assert_eq!(pair_from_str.quote, "USD");
+
+        let pair_from_str = Pair::from("ETH_USDT");
+        assert_eq!(pair_from_str.base, "ETH");
+        assert_eq!(pair_from_str.quote, "USDT");
+
+        let pair_from_str = Pair::from("BTC/USD");
+        assert_eq!(pair_from_str.base, "BTC");
+        assert_eq!(pair_from_str.quote, "USD");
+
+        // Test From<(String, String)>
+        let pair_from_tuple = Pair::from((String::from("btc"), String::from("usdt")));
+        assert_eq!(pair_from_tuple.base, "BTC");
+        assert_eq!(pair_from_tuple.quote, "USDT");
+
+        // Using into()
+        let pair_from_tuple: Pair = (String::from("eth"), String::from("usdc")).into();
+        assert_eq!(pair_from_tuple.base, "ETH");
+        assert_eq!(pair_from_tuple.quote, "USDC");
+
+        // Test as_tuple()
+        let pair = Pair::from_currencies("btc", "usd");
+        let (base, quote) = pair.as_tuple();
+        assert_eq!(base, "BTC");
+        assert_eq!(quote, "USD");
+
+        // Test format_with_separator
+        let pair = Pair::from_currencies("btc", "usd");
+        assert_eq!(pair.format_with_separator("/"), "BTC/USD");
+        assert_eq!(pair.format_with_separator("-"), "BTC-USD");
+        assert_eq!(pair.format_with_separator("_"), "BTC_USD");
+        assert_eq!(pair.to_string(), "BTC/USD");
+    }
+
+    // This test is commented out because it would fail at compile time
+    // #[test]
+    // fn test_invalid_pair() {
+    //     let _pair = generate_pair!("BTC/USD/EUR"); // This will fail at compile time
+    // }
+}

--- a/pragma-common/src/types/pair.rs
+++ b/pragma-common/src/types/pair.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
@@ -76,6 +78,14 @@ impl From<String> for Pair {
     }
 }
 
+impl FromStr for Pair {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self::from(s))
+    }
+}
+
 impl From<(String, String)> for Pair {
     fn from(pair: (String, String)) -> Self {
         Self {
@@ -86,7 +96,7 @@ impl From<(String, String)> for Pair {
 }
 
 #[macro_export]
-macro_rules! generate_pair {
+macro_rules! pair {
     ($pair_str:expr) => {{
         #[allow(dead_code)]
         const fn validate_pair(s: &str) -> bool {
@@ -121,24 +131,24 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_generate_pair_macro() {
-        let pair1 = generate_pair!("BTC/USD");
+    fn test_pair_macro() {
+        let pair1 = pair!("BTC/USD");
         assert_eq!(pair1.base, "BTC");
         assert_eq!(pair1.quote, "USD");
 
-        let pair2 = generate_pair!("btc-usd");
+        let pair2 = pair!("btc-usd");
         assert_eq!(pair2.base, "BTC");
         assert_eq!(pair2.quote, "USD");
 
-        let pair3 = generate_pair!("eth_usdt");
+        let pair3 = pair!("eth_usdt");
         assert_eq!(pair3.base, "ETH");
         assert_eq!(pair3.quote, "USDT");
 
-        let pair4 = generate_pair!("SOL/usdc");
+        let pair4 = pair!("SOL/usdc");
         assert_eq!(pair4.base, "SOL");
         assert_eq!(pair4.quote, "USDC");
 
-        let pair5 = generate_pair!("bTc/uSDt");
+        let pair5 = pair!("bTc/uSDt");
         assert_eq!(pair5.base, "BTC");
         assert_eq!(pair5.quote, "USDT");
     }

--- a/pragma-node/src/handlers/get_expiries.rs
+++ b/pragma-node/src/handlers/get_expiries.rs
@@ -2,13 +2,12 @@ use axum::extract::State;
 use axum::Json;
 use chrono::NaiveDateTime;
 
+use pragma_common::types::pair::Pair;
 use pragma_entities::EntryError;
 
 use crate::infra::repositories::entry_repository;
 use crate::utils::PathExtractor;
 use crate::AppState;
-
-use crate::utils::currency_pair_to_pair_id;
 
 #[utoipa::path(
     get,
@@ -26,11 +25,11 @@ pub async fn get_expiries(
     State(state): State<AppState>,
     PathExtractor(pair): PathExtractor<(String, String)>,
 ) -> Result<Json<Vec<NaiveDateTime>>, EntryError> {
-    let pair_id = currency_pair_to_pair_id(&pair.0, &pair.1);
+    let pair = Pair::from(pair);
 
-    let req_result = entry_repository::get_expiries_list(&state.offchain_pool, pair_id.clone())
+    let req_result = entry_repository::get_expiries_list(&state.offchain_pool, pair.to_pair_id())
         .await
-        .map_err(|e| e.to_entry_error(&(pair_id)))?;
+        .map_err(|e| e.to_entry_error(&(pair.into())))?;
 
     Ok(Json(req_result))
 }

--- a/pragma-node/src/handlers/publish_entry_ws.rs
+++ b/pragma-node/src/handlers/publish_entry_ws.rs
@@ -21,11 +21,7 @@ use axum::http::StatusCode;
 use axum::response::IntoResponse;
 
 // Session expiry time in minutes
-const SESSION_EXPIRY_MINUTES: u64 = 5;
-
-lazy_static::lazy_static! {
-    static ref SESSION_EXPIRY_DURATION: Duration = Duration::from_secs(SESSION_EXPIRY_MINUTES * 60);
-}
+const SESSION_EXPIRY_DURATION: Duration = Duration::from_secs(5 * 60);
 
 #[derive(Debug)]
 pub struct PublisherSession {
@@ -46,7 +42,7 @@ impl PublisherSession {
     fn is_expired(&self) -> bool {
         SystemTime::now()
             .duration_since(self.login_time)
-            .map(|duration| duration > *SESSION_EXPIRY_DURATION)
+            .map(|duration| duration > SESSION_EXPIRY_DURATION)
             .unwrap_or(true)
     }
 

--- a/pragma-node/src/infra/repositories/onchain_repository/entry.rs
+++ b/pragma-node/src/infra/repositories/onchain_repository/entry.rs
@@ -5,6 +5,7 @@ use deadpool_diesel::postgres::Pool;
 use diesel::sql_types::{Numeric, Text, Timestamp, VarChar};
 use diesel::{Queryable, QueryableByName, RunQueryDsl};
 
+use pragma_common::types::pair::Pair;
 use pragma_common::types::{AggregationMode, DataType, Interval, Network};
 use pragma_entities::error::{adapt_infra_error, InfraError};
 use pragma_entities::Currency;
@@ -92,7 +93,8 @@ pub async fn routing(
         )
         .await?;
         if !prices_and_entries.is_empty() {
-            let decimal = get_decimals(offchain_pool, &pair_id).await?;
+            let pair = Pair::from(pair_id.clone());
+            let decimal = get_decimals(offchain_pool, &pair).await?;
             for row in prices_and_entries {
                 result.push(RawOnchainData {
                     price: row.aggregated_price,
@@ -134,7 +136,8 @@ pub async fn routing(
                 routing_args.aggregation_mode,
             )
             .await?;
-            let base_alt_decimal = get_decimals(offchain_pool, &base_alt_pair).await?;
+            let base_alt_decimal =
+                get_decimals(offchain_pool, &Pair::from(base_alt_pair.clone())).await?;
             let quote_alt_result = get_sources_and_aggregate(
                 onchain_pool,
                 routing_args.network,
@@ -143,7 +146,8 @@ pub async fn routing(
                 routing_args.aggregation_mode,
             )
             .await?;
-            let quote_alt_decimal = get_decimals(offchain_pool, &alt_quote_pair).await?;
+            let quote_alt_decimal =
+                get_decimals(offchain_pool, &Pair::from(alt_quote_pair.clone())).await?;
 
             let result = compute_multiple_rebased_price(
                 &mut base_alt_result,

--- a/pragma-node/src/utils/conversion.rs
+++ b/pragma-node/src/utils/conversion.rs
@@ -47,27 +47,3 @@ pub fn format_bigdecimal_price(price: BigDecimal, decimals: u32) -> String {
     }
     formatted_price
 }
-
-/// Converts two currencies pairs to a new routed pair id.
-///
-/// e.g "btc/usd" and "eth/usd" to "btc/eth"
-pub fn currency_pairs_to_routed_pair_id(base_pair: &str, quote_pair: &str) -> String {
-    let (base, _) = pair_id_to_currency_pair(base_pair);
-    let (quote, _) = pair_id_to_currency_pair(quote_pair);
-    format!("{}/{}", base.to_uppercase(), quote.to_uppercase())
-}
-
-/// Converts a currency pair to a pair id.
-///
-/// e.g "btc" and "usd" to "BTC/USD"
-pub fn currency_pair_to_pair_id(base: &str, quote: &str) -> String {
-    format!("{}/{}", base.to_uppercase(), quote.to_uppercase())
-}
-
-/// Converts a pair_id to a currency pair.
-///
-/// e.g "BTC/USD" to ("BTC", "USD")
-pub fn pair_id_to_currency_pair(pair_id: &str) -> (String, String) {
-    let parts: Vec<&str> = pair_id.split('/').collect();
-    (parts[0].to_string(), parts[1].to_string())
-}

--- a/pragma-node/src/utils/mod.rs
+++ b/pragma-node/src/utils/mod.rs
@@ -1,13 +1,11 @@
 pub use aws::PragmaSignerBuilder;
-pub use conversion::{
-    convert_via_quote, currency_pair_to_pair_id, currency_pairs_to_routed_pair_id,
-    format_bigdecimal_price, normalize_to_decimals, pair_id_to_currency_pair,
-};
+pub use conversion::{convert_via_quote, format_bigdecimal_price, normalize_to_decimals};
 pub use custom_extractors::path_extractor::PathExtractor;
 pub use kafka::publish_to_kafka;
 use moka::future::Cache;
 use pragma_common::timestamp::TimestampRangeError;
 use pragma_common::types::entries::Entry;
+use pragma_common::types::pair::Pair;
 use pragma_entities::dto::Publisher;
 pub use ws::*;
 
@@ -42,13 +40,13 @@ pub(crate) fn get_decimals_for_pair(
     currencies: &HashMap<String, BigDecimal>,
     pair_id: &str,
 ) -> u32 {
-    let (base, quote) = pair_id_to_currency_pair(pair_id);
+    let pair = Pair::from(pair_id);
     let base_decimals = currencies
-        .get(&base)
+        .get(&pair.base)
         .map(|d| d.to_u32().unwrap_or(8))
         .unwrap_or(8);
     let quote_decimals = currencies
-        .get(&quote)
+        .get(&pair.quote)
         .map(|d| d.to_u32().unwrap_or(8))
         .unwrap_or(8);
     std::cmp::min(base_decimals, quote_decimals)


### PR DESCRIPTION
Closes #119 

This PR introduces a new `Pair` type in the `pragma-common` module to replace string-based pair handling.

## Changes

- Adding a new `pair.rs` module in `pragma-common/src/types/`
- Refactoring pair-related utility functions to use the new `Pair` struct
- Updating repositories and handlers to use the new `Pair` type
- Simplifying pair conversion and manipulation logic
- Removing deprecated conversion utility functions

The new `Pair` type provides a more type-safe and structured approach to handling currency pairs throughout the project.