### PR TITLE
fix: Last updated timestamp

### DIFF
--- a/pragma-entities/src/lib.rs
+++ b/pragma-entities/src/lib.rs
@@ -2,8 +2,11 @@ pub mod connection;
 pub mod db;
 pub mod dto;
 pub mod error;
+pub mod macros;
 pub mod models;
 pub mod schema;
+
+pub use models::entries::entry_error::EntryError;
 
 // exporting for idiomatic use
 pub use error::{adapt_infra_error, InfraError};
@@ -11,7 +14,7 @@ pub use models::{
     checkpoint_error::CheckpointError,
     currency::Currency,
     entry::{Entry, NewEntry},
-    entry_error::{EntryError, VolatilityError},
+    entry_error::VolatilityError,
     future_entry::{FutureEntry, NewFutureEntry},
     publisher::{NewPublisher, Publishers},
     publisher_error::PublisherError,

--- a/pragma-entities/src/macros.rs
+++ b/pragma-entities/src/macros.rs
@@ -1,0 +1,184 @@
+/// Convert entry to database format
+///
+/// Arguments:
+/// * `entry`: Entry to convert
+/// * `signature`: Signature to use
+///
+/// Returns:
+/// * `NewEntry`: New entry
+#[macro_export]
+macro_rules! convert_timestamp_to_datetime {
+    ($timestamp:expr) => {{
+        if $timestamp > (i64::MAX as u64).try_into().unwrap() {
+            Err(EntryError::InvalidTimestamp(
+                pragma_common::timestamp::TimestampRangeError::Other(format!(
+                    "Timestamp {} is too large",
+                    $timestamp
+                )),
+            ))
+        } else if $timestamp.to_string().len() >= 13 {
+            chrono::DateTime::<chrono::Utc>::from_timestamp_millis($timestamp as i64)
+                .map(|dt| dt.naive_utc())
+                .ok_or_else(|| {
+                    EntryError::InvalidTimestamp(
+                        pragma_common::timestamp::TimestampRangeError::Other(format!(
+                            "Could not convert {} to DateTime (millis)",
+                            $timestamp
+                        )),
+                    )
+                })
+        } else {
+            chrono::DateTime::<chrono::Utc>::from_timestamp($timestamp as i64, 0)
+                .map(|dt| dt.naive_utc())
+                .ok_or_else(|| {
+                    EntryError::InvalidTimestamp(
+                        pragma_common::timestamp::TimestampRangeError::Other(format!(
+                            "Could not convert {} to DateTime (seconds)",
+                            $timestamp
+                        )),
+                    )
+                })
+        }
+    }};
+}
+
+#[cfg(test)]
+mod tests {
+
+    use crate::EntryError;
+    use chrono::TimeZone;
+    use chrono::Utc;
+
+    #[test]
+    fn test_current_timestamp() {
+        let now = Utc::now().timestamp() as u64;
+        let result = convert_timestamp_to_datetime!(now);
+        assert!(result.is_ok());
+        let dt = result.unwrap();
+        assert_eq!(dt.and_utc().timestamp(), now as i64);
+    }
+
+    #[test]
+    fn test_current_timestamp_millis() {
+        let now_millis = Utc::now().timestamp_millis() as u64;
+        let result = convert_timestamp_to_datetime!(now_millis);
+        assert!(result.is_ok());
+        let dt = result.unwrap();
+        assert_eq!(dt.and_utc().timestamp_millis(), now_millis as i64);
+    }
+
+    #[test]
+    fn test_specific_date() {
+        // 2024-03-14 15:92:65 UTC (Pi Day!)
+        let timestamp = 1710428585_u64;
+        let result = convert_timestamp_to_datetime!(timestamp);
+        assert!(result.is_ok());
+        let dt = result.unwrap();
+        let expected = Utc
+            .timestamp_opt(timestamp as i64, 0)
+            .single()
+            .expect("Invalid timestamp")
+            .naive_utc();
+        assert_eq!(dt, expected);
+    }
+
+    #[test]
+    fn test_specific_date_millis() {
+        // 2024-03-14 15:92:65.123 UTC
+        let timestamp_millis = 1710428585123_u64;
+        let result = convert_timestamp_to_datetime!(timestamp_millis);
+        assert!(result.is_ok());
+        let dt = result.unwrap();
+        let expected = Utc
+            .timestamp_millis_opt(timestamp_millis as i64)
+            .single()
+            .expect("Invalid timestamp")
+            .naive_utc();
+        assert_eq!(dt, expected);
+    }
+
+    #[test]
+    fn test_boundary_timestamps() {
+        // Test earliest valid timestamp (1970-01-01 00:00:00 UTC)
+        let earliest = 0_u64;
+        let result = convert_timestamp_to_datetime!(earliest);
+        assert!(result.is_ok());
+        let dt = result.unwrap();
+        assert_eq!(dt.and_utc().timestamp(), 0);
+
+        // Test a very old timestamp (1970-01-02)
+        let old = 86400_u64;
+        let result = convert_timestamp_to_datetime!(old);
+        assert!(result.is_ok());
+        let dt = result.unwrap();
+        assert_eq!(dt.and_utc().timestamp(), 86400);
+
+        // Test a far future timestamp (2100-01-01)
+        let future = 4102444800_u64;
+        let result = convert_timestamp_to_datetime!(future);
+        assert!(result.is_ok());
+        let dt = result.unwrap();
+        assert_eq!(dt.and_utc().timestamp(), future as i64);
+    }
+
+    #[test]
+    fn test_invalid_timestamps() {
+        // Test maximum u64 value
+        let max_u64 = u64::MAX;
+        let result = convert_timestamp_to_datetime!(max_u64);
+        assert!(result.is_err());
+
+        // Test value that's too large for i64 (milliseconds)
+        let too_large_millis = (i64::MAX as u64) + 1;
+        let result = convert_timestamp_to_datetime!(too_large_millis);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_edge_cases() {
+        // Test timestamp just below millisecond threshold (12 digits)
+        let just_below_millis = 999999999999_u64;
+        let result = convert_timestamp_to_datetime!(just_below_millis);
+        assert!(result.is_ok());
+        let dt = result.unwrap();
+        assert_eq!(dt.and_utc().timestamp(), just_below_millis as i64);
+
+        // Test timestamp just at millisecond threshold (13 digits)
+        let just_millis = 1000000000000_u64;
+        let result = convert_timestamp_to_datetime!(just_millis);
+        assert!(result.is_ok());
+        let dt = result.unwrap();
+        assert_eq!(dt.and_utc().timestamp_millis(), just_millis as i64);
+
+        // Test a very recent timestamp
+        let recent = (Utc::now().timestamp() - 1) as u64;
+        let result = convert_timestamp_to_datetime!(recent);
+        assert!(result.is_ok());
+        let dt = result.unwrap();
+        assert_eq!(dt.and_utc().timestamp(), recent as i64);
+    }
+
+    #[test]
+    fn test_real_world_scenarios() {
+        // Test common exchange timestamp (e.g., Binance style)
+        let binance_style = 1710428585123_u64; // millisecond precision
+        let result = convert_timestamp_to_datetime!(binance_style);
+        assert!(result.is_ok());
+        let dt = result.unwrap();
+        assert_eq!(dt.and_utc().timestamp_millis(), binance_style as i64);
+
+        // Test common blockchain timestamp (e.g., Ethereum block timestamp)
+        let blockchain_style = 1710428585_u64; // second precision
+        let result = convert_timestamp_to_datetime!(blockchain_style);
+        assert!(result.is_ok());
+        let dt = result.unwrap();
+        assert_eq!(dt.and_utc().timestamp(), blockchain_style as i64);
+
+        // Test Unix timestamp with recent date
+        let unix_timestamp = Utc::now().timestamp() as u64;
+        let result = convert_timestamp_to_datetime!(unix_timestamp);
+        assert!(result.is_ok());
+        let dt = result.unwrap();
+        assert_eq!(dt.and_utc().timestamp(), unix_timestamp as i64);
+    }
+}

--- a/pragma-entities/src/models/entries/entry.rs
+++ b/pragma-entities/src/models/entries/entry.rs
@@ -105,9 +105,17 @@ impl Entry {
     pub fn get_last_updated_timestamp(
         conn: &mut PgConnection,
         pair: String,
+        max_timestamp: i64,
     ) -> DieselResult<Option<chrono::NaiveDateTime>> {
+        let Some(max_timestamp) = chrono::DateTime::from_timestamp(max_timestamp, 0) else {
+            return Err(diesel::result::Error::DatabaseError(
+                diesel::result::DatabaseErrorKind::CheckViolation,
+                Box::new(format!("Invalid timestamp value: {}", max_timestamp)),
+            ));
+        };
         entries::table
             .filter(entries::pair_id.eq(pair))
+            .filter(entries::timestamp.le(max_timestamp))
             .select(entries::timestamp)
             .order(entries::timestamp.desc())
             .first(conn)

--- a/pragma-node/src/handlers/get_entry.rs
+++ b/pragma-node/src/handlers/get_entry.rs
@@ -117,14 +117,17 @@ pub async fn get_entry(
     let pair = Pair::from(pair);
 
     let (entry, decimals) =
-        entry_repository::routing(&state.offchain_pool, is_routing, &pair, routing_params)
+        entry_repository::routing(&state.offchain_pool, is_routing, &pair, &routing_params)
             .await
             .map_err(|e| e.to_entry_error(&(pair.to_pair_id())))?;
 
-    let last_updated_timestamp: NaiveDateTime =
-        entry_repository::get_last_updated_timestamp(&state.offchain_pool, pair.to_pair_id())
-            .await?
-            .unwrap_or(entry.time);
+    let last_updated_timestamp: NaiveDateTime = entry_repository::get_last_updated_timestamp(
+        &state.offchain_pool,
+        pair.to_pair_id(),
+        routing_params.timestamp,
+    )
+    .await?
+    .unwrap_or(entry.time);
 
     Ok(Json(adapt_entry_to_entry_response(
         pair.into(),

--- a/pragma-node/src/infra/repositories/entry_repository.rs
+++ b/pragma-node/src/infra/repositories/entry_repository.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
 use bigdecimal::{BigDecimal, FromPrimitive, ToPrimitive};
-use chrono::{DateTime, NaiveDateTime, Utc};
+use chrono::{DateTime, NaiveDateTime};
 use diesel::prelude::QueryableByName;
 use diesel::sql_types::{Double, Jsonb, VarChar};
 use diesel::{ExpressionMethods, QueryDsl, Queryable, RunQueryDsl};
@@ -153,7 +153,7 @@ pub async fn routing(
                 .unwrap_or(NaiveDateTime::default())
                 .and_utc()
                 .timestamp()
-                >= Utc::now().naive_utc().and_utc().timestamp() - ROUTING_FRESHNESS_THRESHOLD)
+                >= routing_params.timestamp - ROUTING_FRESHNESS_THRESHOLD)
     {
         return get_price_and_decimals(pool, pair, routing_params).await;
     }

--- a/pragma-node/src/utils/mod.rs
+++ b/pragma-node/src/utils/mod.rs
@@ -3,7 +3,6 @@ pub use conversion::{convert_via_quote, format_bigdecimal_price, normalize_to_de
 pub use custom_extractors::path_extractor::PathExtractor;
 pub use kafka::publish_to_kafka;
 use moka::future::Cache;
-use pragma_common::timestamp::TimestampRangeError;
 use pragma_common::types::entries::Entry;
 use pragma_common::types::pair::Pair;
 use pragma_entities::dto::Publisher;
@@ -11,10 +10,13 @@ pub use ws::*;
 
 use bigdecimal::num_bigint::ToBigInt;
 use bigdecimal::{BigDecimal, ToPrimitive};
-use chrono::{DateTime, NaiveDateTime, Utc};
+use chrono::NaiveDateTime;
 use deadpool_diesel::postgres::Pool;
 use pragma_common::types::Network;
-use pragma_entities::{Entry as EntityEntry, EntryError, FutureEntry, NewEntry, PublisherError};
+use pragma_entities::{
+    convert_timestamp_to_datetime, Entry as EntityEntry, EntryError, FutureEntry, NewEntry,
+    PublisherError,
+};
 use starknet_crypto::{Felt, Signature};
 use std::collections::HashMap;
 
@@ -91,43 +93,6 @@ pub(crate) async fn is_onchain_existing_pair(pool: &Pool, pair: &String, network
         .expect("Couldn't get the existing pairs from the database.");
 
     existings_pairs.into_iter().any(|p| p.pair_id == *pair)
-}
-
-/// Convert entry to database format
-///
-/// Arguments:
-/// * `entry`: Entry to convert
-/// * `signature`: Signature to use
-///
-/// Returns:
-/// * `NewEntry`: New entry
-#[macro_export]
-macro_rules! convert_timestamp_to_datetime {
-    ($timestamp:expr) => {{
-        if $timestamp > i64::MAX as u64 {
-            Err(EntryError::InvalidTimestamp(TimestampRangeError::Other(
-                format!("Timestamp {} is too large", $timestamp),
-            )))
-        } else if $timestamp.to_string().len() >= 13 {
-            DateTime::<Utc>::from_timestamp_millis($timestamp as i64)
-                .map(|dt| dt.naive_utc())
-                .ok_or_else(|| {
-                    EntryError::InvalidTimestamp(TimestampRangeError::Other(format!(
-                        "Could not convert {} to DateTime (millis)",
-                        $timestamp
-                    )))
-                })
-        } else {
-            DateTime::<Utc>::from_timestamp($timestamp as i64, 0)
-                .map(|dt| dt.naive_utc())
-                .ok_or_else(|| {
-                    EntryError::InvalidTimestamp(TimestampRangeError::Other(format!(
-                        "Could not convert {} to DateTime (seconds)",
-                        $timestamp
-                    )))
-                })
-        }
-    }};
 }
 
 pub fn convert_entry_to_db(entry: &Entry, signature: &Signature) -> Result<NewEntry, EntryError> {
@@ -281,7 +246,7 @@ pub async fn validate_publisher(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chrono::{DateTime, TimeZone, Utc};
+    use chrono::{TimeZone, Utc};
 
     fn new_entry(median_price: u32, timestamp: i64) -> MedianEntry {
         MedianEntry {
@@ -292,143 +257,6 @@ mod tests {
                 .naive_utc(),
             median_price: median_price.into(),
             num_sources: 5,
-        }
-    }
-
-    mod timestamp_conversion {
-        use super::*;
-
-        #[test]
-        fn test_current_timestamp() {
-            let now = Utc::now().timestamp() as u64;
-            let result = convert_timestamp_to_datetime!(now);
-            assert!(result.is_ok());
-            let dt = result.unwrap();
-            assert_eq!(dt.and_utc().timestamp(), now as i64);
-        }
-
-        #[test]
-        fn test_current_timestamp_millis() {
-            let now_millis = Utc::now().timestamp_millis() as u64;
-            let result = convert_timestamp_to_datetime!(now_millis);
-            assert!(result.is_ok());
-            let dt = result.unwrap();
-            assert_eq!(dt.and_utc().timestamp_millis(), now_millis as i64);
-        }
-
-        #[test]
-        fn test_specific_date() {
-            // 2024-03-14 15:92:65 UTC (Pi Day!)
-            let timestamp = 1710428585_u64;
-            let result = convert_timestamp_to_datetime!(timestamp);
-            assert!(result.is_ok());
-            let dt = result.unwrap();
-            let expected = Utc
-                .timestamp_opt(timestamp as i64, 0)
-                .single()
-                .expect("Invalid timestamp")
-                .naive_utc();
-            assert_eq!(dt, expected);
-        }
-
-        #[test]
-        fn test_specific_date_millis() {
-            // 2024-03-14 15:92:65.123 UTC
-            let timestamp_millis = 1710428585123_u64;
-            let result = convert_timestamp_to_datetime!(timestamp_millis);
-            assert!(result.is_ok());
-            let dt = result.unwrap();
-            let expected = Utc
-                .timestamp_millis_opt(timestamp_millis as i64)
-                .single()
-                .expect("Invalid timestamp")
-                .naive_utc();
-            assert_eq!(dt, expected);
-        }
-
-        #[test]
-        fn test_boundary_timestamps() {
-            // Test earliest valid timestamp (1970-01-01 00:00:00 UTC)
-            let earliest = 0_u64;
-            let result = convert_timestamp_to_datetime!(earliest);
-            assert!(result.is_ok());
-            let dt = result.unwrap();
-            assert_eq!(dt.and_utc().timestamp(), 0);
-
-            // Test a very old timestamp (1970-01-02)
-            let old = 86400_u64;
-            let result = convert_timestamp_to_datetime!(old);
-            assert!(result.is_ok());
-            let dt = result.unwrap();
-            assert_eq!(dt.and_utc().timestamp(), 86400);
-
-            // Test a far future timestamp (2100-01-01)
-            let future = 4102444800_u64;
-            let result = convert_timestamp_to_datetime!(future);
-            assert!(result.is_ok());
-            let dt = result.unwrap();
-            assert_eq!(dt.and_utc().timestamp(), future as i64);
-        }
-
-        #[test]
-        fn test_invalid_timestamps() {
-            // Test maximum u64 value
-            let max_u64 = u64::MAX;
-            let result = convert_timestamp_to_datetime!(max_u64);
-            assert!(result.is_err());
-
-            // Test value that's too large for i64 (milliseconds)
-            let too_large_millis = (i64::MAX as u64) + 1;
-            let result = convert_timestamp_to_datetime!(too_large_millis);
-            assert!(result.is_err());
-        }
-
-        #[test]
-        fn test_edge_cases() {
-            // Test timestamp just below millisecond threshold (12 digits)
-            let just_below_millis = 999999999999_u64;
-            let result = convert_timestamp_to_datetime!(just_below_millis);
-            assert!(result.is_ok());
-            let dt = result.unwrap();
-            assert_eq!(dt.and_utc().timestamp(), just_below_millis as i64);
-
-            // Test timestamp just at millisecond threshold (13 digits)
-            let just_millis = 1000000000000_u64;
-            let result = convert_timestamp_to_datetime!(just_millis);
-            assert!(result.is_ok());
-            let dt = result.unwrap();
-            assert_eq!(dt.and_utc().timestamp_millis(), just_millis as i64);
-
-            // Test a very recent timestamp
-            let recent = (Utc::now().timestamp() - 1) as u64;
-            let result = convert_timestamp_to_datetime!(recent);
-            assert!(result.is_ok());
-            let dt = result.unwrap();
-            assert_eq!(dt.and_utc().timestamp(), recent as i64);
-        }
-
-        #[test]
-        fn test_real_world_scenarios() {
-            // Test common exchange timestamp (e.g., Binance style)
-            let binance_style = 1710428585123_u64; // millisecond precision
-            let result = convert_timestamp_to_datetime!(binance_style);
-            assert!(result.is_ok());
-            let dt = result.unwrap();
-            assert_eq!(dt.and_utc().timestamp_millis(), binance_style as i64);
-
-            // Test common blockchain timestamp (e.g., Ethereum block timestamp)
-            let blockchain_style = 1710428585_u64; // second precision
-            let result = convert_timestamp_to_datetime!(blockchain_style);
-            assert!(result.is_ok());
-            let dt = result.unwrap();
-            assert_eq!(dt.and_utc().timestamp(), blockchain_style as i64);
-
-            // Test Unix timestamp with recent date
-            let unix_timestamp = Utc::now().timestamp() as u64;
-            let result = convert_timestamp_to_datetime!(unix_timestamp);
-            assert!(result.is_ok());
-            let dt = result.unwrap();
-            assert_eq!(dt.and_utc().timestamp(), unix_timestamp as i64);
         }
     }
 


### PR DESCRIPTION
Resolves: #175 

The last updated timestamp is now correctly restricted when a `timestamp` parameter is provided.