### PR TITLE
feat: Add MarketEntry enum to support multiple market types

### DIFF
--- a/pragma-common/src/types/entries.rs
+++ b/pragma-common/src/types/entries.rs
@@ -20,42 +20,42 @@ pub enum MarketEntry {
     #[serde(rename = "spot")]
     Spot(Entry),
     #[serde(rename = "perp")]
-    Perp(PerpEntry)
+    Perp(PerpEntry),
 }
 
 impl EntryTrait for MarketEntry {
     fn base(&self) -> &BaseEntry {
         match self {
-            MarketEntry::Spot(entry) => entry.base(),
-            MarketEntry::Perp(entry) => entry.base(),
+            Self::Spot(entry) => entry.base(),
+            Self::Perp(entry) => entry.base(),
         }
     }
 
     fn pair_id(&self) -> &String {
         match self {
-            MarketEntry::Spot(entry) => entry.pair_id(),
-            MarketEntry::Perp(entry) => entry.pair_id(),
+            Self::Spot(entry) => entry.pair_id(),
+            Self::Perp(entry) => entry.pair_id(),
         }
     }
 
     fn price(&self) -> u128 {
         match self {
-            MarketEntry::Spot(entry) => entry.price(),
-            MarketEntry::Perp(entry) => entry.price(),
+            Self::Spot(entry) => entry.price(),
+            Self::Perp(entry) => entry.price(),
         }
     }
 
     fn volume(&self) -> u128 {
         match self {
-            MarketEntry::Spot(entry) => entry.volume(),
-            MarketEntry::Perp(entry) => entry.volume(),
+            Self::Spot(entry) => entry.volume(),
+            Self::Perp(entry) => entry.volume(),
         }
     }
 
     fn expiration_timestamp(&self) -> Option<u64> {
         match self {
-            MarketEntry::Spot(entry) => entry.expiration_timestamp(),
-            MarketEntry::Perp(entry) => entry.expiration_timestamp(),
+            Self::Spot(entry) => entry.expiration_timestamp(),
+            Self::Perp(entry) => entry.expiration_timestamp(),
         }
     }
 }
@@ -63,8 +63,8 @@ impl EntryTrait for MarketEntry {
 impl fmt::Display for MarketEntry {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            MarketEntry::Spot(entry) => write!(f, "spot: {}", entry),
-            MarketEntry::Perp(entry) => write!(f, "perp: {}", entry),
+            Self::Spot(entry) => write!(f, "spot: {entry}"),
+            Self::Perp(entry) => write!(f, "perp: {entry}"),
         }
     }
 }

--- a/pragma-common/src/types/entries.rs
+++ b/pragma-common/src/types/entries.rs
@@ -14,6 +14,61 @@ pub struct BaseEntry {
     pub publisher: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
+#[serde(tag = "type", content = "data")]
+pub enum MarketEntry {
+    #[serde(rename = "spot")]
+    Spot(Entry),
+    #[serde(rename = "perp")]
+    Perp(PerpEntry)
+}
+
+impl EntryTrait for MarketEntry {
+    fn base(&self) -> &BaseEntry {
+        match self {
+            MarketEntry::Spot(entry) => entry.base(),
+            MarketEntry::Perp(entry) => entry.base(),
+        }
+    }
+
+    fn pair_id(&self) -> &String {
+        match self {
+            MarketEntry::Spot(entry) => entry.pair_id(),
+            MarketEntry::Perp(entry) => entry.pair_id(),
+        }
+    }
+
+    fn price(&self) -> u128 {
+        match self {
+            MarketEntry::Spot(entry) => entry.price(),
+            MarketEntry::Perp(entry) => entry.price(),
+        }
+    }
+
+    fn volume(&self) -> u128 {
+        match self {
+            MarketEntry::Spot(entry) => entry.volume(),
+            MarketEntry::Perp(entry) => entry.volume(),
+        }
+    }
+
+    fn expiration_timestamp(&self) -> Option<u64> {
+        match self {
+            MarketEntry::Spot(entry) => entry.expiration_timestamp(),
+            MarketEntry::Perp(entry) => entry.expiration_timestamp(),
+        }
+    }
+}
+
+impl fmt::Display for MarketEntry {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            MarketEntry::Spot(entry) => write!(f, "spot: {}", entry),
+            MarketEntry::Perp(entry) => write!(f, "perp: {}", entry),
+        }
+    }
+}
+
 pub trait EntryTrait {
     fn base(&self) -> &BaseEntry;
     fn pair_id(&self) -> &String;

--- a/pragma-node/src/handlers/publish_entry_ws.rs
+++ b/pragma-node/src/handlers/publish_entry_ws.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 use utoipa::ToSchema;
 
-use pragma_common::types::auth::{build_login_message, LoginMessage};
+use pragma_common::types::auth::{LoginMessage, build_login_message};
 use pragma_common::types::entries::MarketEntry;
 use pragma_entities::EntryError;
 use starknet_crypto::{Felt, Signature};
@@ -13,6 +13,12 @@ use axum::extract::ws::{WebSocket, WebSocketUpgrade};
 use axum::extract::{ConnectInfo, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
+
+use crate::AppState;
+use crate::handlers::create_entry::CreateEntryResponse;
+use crate::utils::{ChannelHandler, Subscriber, WebSocketError, convert_market_entry_to_db};
+use crate::utils::{publish_to_kafka, validate_publisher};
+use pragma_common::signing::assert_login_is_valid;
 
 // Session expiry time in minutes
 const SESSION_EXPIRY_DURATION: Duration = Duration::from_secs(5 * 60);

--- a/pragma-node/src/handlers/publish_entry_ws.rs
+++ b/pragma-node/src/handlers/publish_entry_ws.rs
@@ -4,14 +4,8 @@ use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 use utoipa::ToSchema;
 
-use crate::AppState;
-use crate::handlers::create_entry::CreateEntryResponse;
-use crate::utils::{ChannelHandler, Subscriber, WebSocketError};
-use crate::utils::{convert_entry_to_db, publish_to_kafka, validate_publisher};
-use pragma_common::signing::assert_login_is_valid;
-use pragma_common::types::auth::{LoginMessage, build_login_message};
-use pragma_common::types::entries::Entry;
-
+use pragma_common::types::auth::{build_login_message, LoginMessage};
+use pragma_common::types::entries::MarketEntry;
 use pragma_entities::EntryError;
 use starknet_crypto::{Felt, Signature};
 
@@ -55,7 +49,7 @@ impl PublisherSession {
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct PublishEntryRequest {
-    pub entries: Vec<Entry>,
+    pub entries: Vec<MarketEntry>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -361,7 +355,7 @@ async fn process_entries_without_verification(
         .entries
         .iter()
         .map(|entry| {
-            convert_entry_to_db(
+            convert_market_entry_to_db(
                 entry,
                 &Signature {
                     r: Felt::ZERO,

--- a/pragma-node/src/utils/mod.rs
+++ b/pragma-node/src/utils/mod.rs
@@ -21,7 +21,7 @@ use moka::future::Cache;
 use starknet_crypto::{Felt, Signature};
 
 use pragma_common::types::Network;
-use pragma_common::types::entries::Entry;
+use pragma_common::types::entries::{Entry, MarketEntry};
 use pragma_entities::dto::Publisher;
 use pragma_entities::{
     Entry as EntityEntry, EntryError, FutureEntry, NewEntry, PublisherError,
@@ -86,6 +86,21 @@ pub fn convert_entry_to_db(entry: &Entry, signature: &Signature) -> Result<NewEn
         timestamp: dt,
         publisher_signature: format!("0x{signature}"),
         price: entry.price.into(),
+    })
+}
+
+pub fn convert_market_entry_to_db(entry: &MarketEntry, signature: &Signature) -> Result<NewEntry, EntryError> {
+    let base = entry.base();
+    let dt = convert_timestamp_to_datetime!(base.timestamp)?;
+    let signature_str = format!("0x{signature}");
+
+    Ok(NewEntry {
+        pair_id: entry.pair_id().clone(),
+        publisher: base.publisher.clone(),
+        source: base.source.clone(),
+        timestamp: dt,
+        publisher_signature: signature_str,
+        price: entry.price().into(),
     })
 }
 

--- a/pragma-node/src/utils/mod.rs
+++ b/pragma-node/src/utils/mod.rs
@@ -89,7 +89,10 @@ pub fn convert_entry_to_db(entry: &Entry, signature: &Signature) -> Result<NewEn
     })
 }
 
-pub fn convert_market_entry_to_db(entry: &MarketEntry, signature: &Signature) -> Result<NewEntry, EntryError> {
+pub fn convert_market_entry_to_db(
+    entry: &MarketEntry,
+    signature: &Signature,
+) -> Result<NewEntry, EntryError> {
     let base = entry.base();
     let dt = convert_timestamp_to_datetime!(base.timestamp)?;
     let signature_str = format!("0x{signature}");

--- a/pragma-node/src/utils/mod.rs
+++ b/pragma-node/src/utils/mod.rs
@@ -11,6 +11,7 @@ pub use aws::PragmaSignerBuilder;
 pub use conversion::{convert_via_quote, format_bigdecimal_price, normalize_to_decimals};
 pub use custom_extractors::path_extractor::PathExtractor;
 pub use kafka::publish_to_kafka;
+use pragma_common::entries::EntryTrait as _;
 pub use ws::*;
 
 use bigdecimal::num_bigint::ToBigInt;


### PR DESCRIPTION
Introduces a new MarketEntry enum in entries.rs to handle both spot and perpetual market entries. Updates related utility functions and handlers to support the new enum, enabling more flexible market data representation.