### PR TITLE
feat: Add WebSocket inactivity timeout

### DIFF
--- a/pragma-entities/src/error.rs
+++ b/pragma-entities/src/error.rs
@@ -10,6 +10,16 @@ use std::{
 use thiserror::Error;
 use utoipa::ToSchema;
 
+#[derive(Debug, Error, ToSchema)]
+pub enum WebSocketError {
+    #[error("could not create a channel with the client")]
+    ChannelInit,
+    #[error("could not decode client message: {0}")]
+    MessageDecode(String),
+    #[error("could not close the channel")]
+    ChannelClose,
+}
+
 #[derive(Debug, Error)]
 pub enum PragmaNodeError {
     #[error("cannot init database pool : {0}")]
@@ -65,6 +75,7 @@ pub enum InfraError {
     NoRpcAvailable(Network),
     // Unknown internal Server Error - should never be shown to the user
     InternalServerError,
+    WebSocketError(#[from] WebSocketError),
 }
 
 impl fmt::Display for InfraError {
@@ -92,6 +103,7 @@ impl fmt::Display for InfraError {
             // Unclassified
             Self::DisputerNotSet => write!(f, "Unable to fetch disputer address"),
             Self::SettlerNotSet => write!(f, "Unable to fetch settler address"),
+            Self::WebSocketError(e) => write!(f, "WebSocket error {e}"),
         }
     }
 }

--- a/pragma-entities/src/models/entries/entry_error.rs
+++ b/pragma-entities/src/models/entries/entry_error.rs
@@ -9,7 +9,7 @@ use pragma_common::timestamp::TimestampError;
 use pragma_common::types::{AggregationMode, Interval};
 
 use crate::PublisherError;
-use crate::error::InfraError;
+use crate::error::{InfraError, WebSocketError};
 
 #[derive(Debug, thiserror::Error, ToSchema)]
 pub enum EntryError {
@@ -56,6 +56,9 @@ pub enum EntryError {
     // 500 Error - Internal server error
     #[error("internal server error: {0}")]
     InternalServerError(String),
+
+    #[error("websocket error: {0}")]
+    WebSocketError(#[from] WebSocketError),
 }
 
 impl From<InfraError> for EntryError {
@@ -129,6 +132,10 @@ impl IntoResponse for EntryError {
             Self::InternalServerError(reason) => (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 format!("Interval server error: {reason}"),
+            ),
+            Self::WebSocketError(err) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("WebSocket error: {err}"),
             ),
         };
 

--- a/pragma-node/src/handlers/publish_entry_ws.rs
+++ b/pragma-node/src/handlers/publish_entry_ws.rs
@@ -1,3 +1,4 @@
+use pragma_entities::error::WebSocketError;
 use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -16,9 +17,7 @@ use axum::response::IntoResponse;
 
 use crate::AppState;
 use crate::handlers::create_entry::CreateEntryResponse;
-use crate::utils::{
-    ChannelHandler, Subscriber, WebSocketError, convert_entry_to_db, convert_perp_entry_to_db,
-};
+use crate::utils::{ChannelHandler, Subscriber, convert_entry_to_db, convert_perp_entry_to_db};
 use crate::utils::{publish_to_kafka, validate_publisher};
 use pragma_common::signing::assert_login_is_valid;
 


### PR DESCRIPTION
## Changes
- On every update interval tick we check if the connection is inactive and if so we close it. To keep the connection alive the client should send any text/binary message or `Ping`
- We set a default timeout of 1min for now