### PR TITLE
feat: enhance detailed median entry with individual prices

### DIFF
--- a/pragma-entities/migrations/2024-01-11-123510_add_continuous_aggregates/down.sql
+++ b/pragma-entities/migrations/2024-01-11-123510_add_continuous_aggregates/down.sql
@@ -24,3 +24,6 @@ DROP MATERIALIZED VIEW IF EXISTS price_1_week_agg_future;
 
 -- Drop the function
 DROP FUNCTION IF EXISTS create_continuous_aggregate;
+
+-- Drop the type
+DROP TYPE IF EXISTS price_component;

--- a/pragma-entities/migrations/2024-01-11-123510_add_continuous_aggregates/up.sql
+++ b/pragma-entities/migrations/2024-01-11-123510_add_continuous_aggregates/up.sql
@@ -2,9 +2,8 @@ CREATE TYPE price_component AS (
     source text,
     publisher text,
     price numeric(1000,0),
-    timestamp timestamptz
+    "timestamp" timestamptz
 );
-
 
 CREATE OR REPLACE FUNCTION create_continuous_aggregate(
     p_name text,
@@ -13,30 +12,68 @@ CREATE OR REPLACE FUNCTION create_continuous_aggregate(
     p_table_name text
 )
 RETURNS void AS $$
+DECLARE
+    interval_text text;
+    internal_base_view_name text;
+    main_view_name text;
 BEGIN
+    interval_text := p_interval::text;
+    internal_base_view_name := p_name || '_internal_base';
+    main_view_name := p_name;
+    
+    -- Step 1: Create source-level continuous aggregate (internal)
     EXECUTE format('
         CREATE MATERIALIZED VIEW %I
-        WITH (timescaledb.continuous, timescaledb.materialized_only = false)
-        AS SELECT 
+        WITH (timescaledb.continuous)
+        AS
+        SELECT 
             pair_id,
-            time_bucket(%L, timestamp) as bucket,
-            (percentile_cont(0.5) WITHIN GROUP (ORDER BY price))::numeric(1000,0) AS median_price,
-            COUNT(DISTINCT source) as num_sources,
-            array_agg(ROW(source, publisher, price, timestamp)::price_component) AS components
+            source,
+            time_bucket(''%s''::interval, "timestamp") as bucket,
+            percentile_cont(0.5) WITHIN GROUP (ORDER BY price)::numeric(1000,0) AS source_median_price,
+            array_agg(ROW(source, publisher, price, "timestamp")::price_component) AS components
         FROM %I
-        GROUP BY bucket, pair_id
-        WITH NO DATA;', p_name, p_interval, p_table_name);
+        WHERE "timestamp" IS NOT NULL
+        GROUP BY pair_id, source, bucket
+        WITH NO DATA', 
+        internal_base_view_name, interval_text, p_table_name);
+        
+    -- Step 2: Create median-of-medians as the main continuous aggregate
+    -- CRITICAL: Must use a fresh time_bucket call directly on the bucket field
+    EXECUTE format('
+        CREATE MATERIALIZED VIEW %I
+        WITH (timescaledb.continuous)
+        AS
+        SELECT 
+            pair_id,
+            time_bucket(''%s''::interval, bucket) as bucket,
+            percentile_cont(0.5) WITHIN GROUP (ORDER BY source_median_price)::numeric(1000,0) AS median_price,
+            COUNT(DISTINCT source) as num_sources,
+            array_agg(components) AS components
+        FROM %I
+        GROUP BY pair_id, time_bucket(''%s''::interval, bucket)
+        WITH NO DATA',
+        main_view_name, interval_text, internal_base_view_name, interval_text);
 
+    -- Add continuous aggregate policies
     EXECUTE format('
         SELECT add_continuous_aggregate_policy(%L,
-            start_offset => %L,
-            end_offset => %L,
-            schedule_interval => %L);', p_name, p_start_offset, '0'::interval, p_interval);
+            start_offset => ''%s''::interval,
+            end_offset => ''0''::interval,
+            schedule_interval => ''%s''::interval)', 
+        internal_base_view_name, p_start_offset::text, p_interval::text);
+        
+    EXECUTE format('
+        SELECT add_continuous_aggregate_policy(%L,
+            start_offset => ''%s''::interval,
+            end_offset => ''0''::interval,
+            schedule_interval => ''%s''::interval)', 
+        main_view_name, p_start_offset::text, p_interval::text);
 END;
 $$ LANGUAGE plpgsql;
 
--- Spot entries aggregates
-SELECT create_continuous_aggregate('price_100_ms_agg', '100 milliseconds'::interval, '300 milliseconds'::interval, 'entries');
+-- Use consistent interval notation for all entries
+SELECT create_continuous_aggregate('price_100_ms_agg', '0.1 seconds'::interval, '0.3 seconds'::interval, 'entries');
 SELECT create_continuous_aggregate('price_1_s_agg', '1 second'::interval, '3 seconds'::interval, 'entries');
 SELECT create_continuous_aggregate('price_10_s_agg', '10 seconds'::interval, '30 seconds'::interval, 'entries');
 SELECT create_continuous_aggregate('price_5_s_agg', '5 seconds'::interval, '15 seconds'::interval, 'entries');
@@ -47,8 +84,8 @@ SELECT create_continuous_aggregate('price_2_h_agg', '2 hours'::interval, '6 hour
 SELECT create_continuous_aggregate('price_1_day_agg', '1 day'::interval, '3 days'::interval, 'entries');
 SELECT create_continuous_aggregate('price_1_week_agg', '1 week'::interval, '3 weeks'::interval, 'entries');
 
--- Future entries aggregates
-SELECT create_continuous_aggregate('price_100_ms_agg_future', '100 milliseconds'::interval, '300 milliseconds'::interval, 'future_entries');
+-- Future entries with same approach
+SELECT create_continuous_aggregate('price_100_ms_agg_future', '0.1 seconds'::interval, '0.3 seconds'::interval, 'future_entries');
 SELECT create_continuous_aggregate('price_1_s_agg_future', '1 second'::interval, '3 seconds'::interval, 'future_entries');
 SELECT create_continuous_aggregate('price_10_s_agg_future', '10 seconds'::interval, '30 seconds'::interval, 'future_entries');
 SELECT create_continuous_aggregate('price_5_s_agg_future', '5 seconds'::interval, '15 seconds'::interval, 'future_entries');

--- a/pragma-entities/migrations/2024-01-11-123510_add_continuous_aggregates/up.sql
+++ b/pragma-entities/migrations/2024-01-11-123510_add_continuous_aggregates/up.sql
@@ -1,3 +1,11 @@
+CREATE TYPE price_component AS (
+    source text,
+    publisher text,
+    price numeric(1000,0),
+    timestamp timestamptz
+);
+
+
 CREATE OR REPLACE FUNCTION create_continuous_aggregate(
     p_name text,
     p_interval interval,
@@ -14,7 +22,7 @@ BEGIN
             time_bucket(%L, timestamp) as bucket,
             (percentile_cont(0.5) WITHIN GROUP (ORDER BY price))::numeric(1000,0) AS median_price,
             COUNT(DISTINCT source) as num_sources,
-            array_agg(ROW(source, publisher, price, timestamp) ORDER BY timestamp) AS components
+            array_agg(ROW(source, publisher, price, timestamp)::price_component) AS components
         FROM %I
         GROUP BY bucket, pair_id
         WITH NO DATA;', p_name, p_interval, p_table_name);

--- a/pragma-entities/migrations/2024-01-11-123510_add_continuous_aggregates/up.sql
+++ b/pragma-entities/migrations/2024-01-11-123510_add_continuous_aggregates/up.sql
@@ -13,8 +13,8 @@ BEGIN
             pair_id,
             time_bucket(%L, timestamp) as bucket,
             (percentile_cont(0.5) WITHIN GROUP (ORDER BY price))::numeric(1000,0) AS median_price,
-            COUNT(DISTINCT source) as num_sources
-            array_agg(ROW(source, publisher, price, timestamp) ORDER BY timestamp) AS individual_prices
+            COUNT(DISTINCT source) as num_sources,
+            array_agg(ROW(source, publisher, price, timestamp) ORDER BY timestamp) AS components
         FROM %I
         GROUP BY bucket, pair_id
         WITH NO DATA;', p_name, p_interval, p_table_name);

--- a/pragma-entities/migrations/2024-01-11-123510_add_continuous_aggregates/up.sql
+++ b/pragma-entities/migrations/2024-01-11-123510_add_continuous_aggregates/up.sql
@@ -14,6 +14,7 @@ BEGIN
             time_bucket(%L, timestamp) as bucket,
             (percentile_cont(0.5) WITHIN GROUP (ORDER BY price))::numeric(1000,0) AS median_price,
             COUNT(DISTINCT source) as num_sources
+            array_agg(ROW(source, publisher, price, timestamp) ORDER BY timestamp) AS individual_prices
         FROM %I
         GROUP BY bucket, pair_id
         WITH NO DATA;', p_name, p_interval, p_table_name);

--- a/pragma-node/src/handlers/get_entry.rs
+++ b/pragma-node/src/handlers/get_entry.rs
@@ -130,9 +130,15 @@ pub async fn get_entry(
 
     let pair = Pair::from(pair);
 
-    let entry = routing(&state.offchain_pool, is_routing, &pair, &entry_params, false)
-        .await
-        .map_err(EntryError::from)?;
+    let entry = routing(
+        &state.offchain_pool,
+        is_routing,
+        &pair,
+        &entry_params,
+        false,
+    )
+    .await
+    .map_err(EntryError::from)?;
 
     let last_updated_timestamp: NaiveDateTime = get_last_updated_timestamp(
         &state.offchain_pool,
@@ -149,7 +155,6 @@ pub async fn get_entry(
     )))
 }
 
-
 pub fn adapt_entry_to_entry_response(
     pair_id: String,
     entry: &MedianEntry,
@@ -161,8 +166,9 @@ pub fn adapt_entry_to_entry_response(
         num_sources_aggregated: entry.num_sources as usize,
         price: big_decimal_price_to_hex(&entry.median_price),
         decimals: EIGHTEEN_DECIMALS,
-        components: entry.components.as_ref().map(|prices| {
-            prices.iter().cloned().map(Into::into).collect()
-        }),
+        components: entry
+            .components
+            .as_ref()
+            .map(|prices| prices.iter().cloned().map(Into::into).collect()),
     }
 }

--- a/pragma-node/src/handlers/stream/common.rs
+++ b/pragma-node/src/handlers/stream/common.rs
@@ -44,9 +44,7 @@ pub async fn get_historical_entries(
     let responses: Vec<GetEntryResponse> = entries
         .into_iter()
         .take(count)
-        .map(|entry| 
-            adapt_entry_to_entry_response(pair.to_pair_id(), &entry, entry.time)
-        )
+        .map(|entry| adapt_entry_to_entry_response(pair.to_pair_id(), &entry, entry.time))
         .collect();
 
     Ok(responses)
@@ -57,15 +55,21 @@ pub async fn get_latest_entry(
     pair: &Pair,
     is_routing: bool,
     entry_params: &EntryParams,
-    with_components: bool
+    with_components: bool,
 ) -> Result<GetEntryResponse, EntryError> {
     // We have to update the timestamp to now every tick
     let mut new_routing = entry_params.clone();
     new_routing.timestamp = chrono::Utc::now().timestamp();
 
-    let entry = entry_repository::routing(&state.offchain_pool, is_routing, pair, &new_routing, with_components)
-        .await
-        .map_err(EntryError::from)?;
+    let entry = entry_repository::routing(
+        &state.offchain_pool,
+        is_routing,
+        pair,
+        &new_routing,
+        with_components,
+    )
+    .await
+    .map_err(EntryError::from)?;
 
     let last_updated_timestamp = entry_repository::get_last_updated_timestamp(
         &state.offchain_pool,
@@ -118,7 +122,7 @@ pub async fn get_latest_entries_multi_pair(
     pairs: &[Pair],
     is_routing: bool,
     entry_params: &EntryParams,
-    with_components: bool
+    with_components: bool,
 ) -> Result<Vec<GetEntryResponse>, EntryError> {
     let mut latest_entries = Vec::with_capacity(pairs.len());
 

--- a/pragma-node/src/handlers/stream/stream_multi.rs
+++ b/pragma-node/src/handlers/stream/stream_multi.rs
@@ -136,8 +136,10 @@ pub async fn stream_entry_multi_pair(
                             }
                         } else {
                             // For subsequent updates, get latest prices for all pairs
-                            match get_latest_entries_multi_pair(&state, &pairs, is_routing, &params, true)
-                                .await
+                            match get_latest_entries_multi_pair(
+                                &state, &pairs, is_routing, &params, true,
+                            )
+                            .await
                             {
                                 Ok(entry_responses) => Event::default()
                                     .json_data(&entry_responses)

--- a/pragma-node/src/handlers/stream/stream_multi.rs
+++ b/pragma-node/src/handlers/stream/stream_multi.rs
@@ -136,7 +136,7 @@ pub async fn stream_entry_multi_pair(
                             }
                         } else {
                             // For subsequent updates, get latest prices for all pairs
-                            match get_latest_entries_multi_pair(&state, &pairs, is_routing, &params)
+                            match get_latest_entries_multi_pair(&state, &pairs, is_routing, &params, true)
                                 .await
                             {
                                 Ok(entry_responses) => Event::default()

--- a/pragma-node/src/handlers/stream/stream_single.rs
+++ b/pragma-node/src/handlers/stream/stream_single.rs
@@ -110,7 +110,8 @@ pub async fn stream_entry(
                             }
                         } else {
                             // For subsequent updates, get latest price
-                            match get_latest_entry(&state, &pair, is_routing, &params, false).await {
+                            match get_latest_entry(&state, &pair, is_routing, &params, false).await
+                            {
                                 Ok(entry_response) => Event::default()
                                     .json_data(&entry_response)
                                     .unwrap_or_else(|e| {

--- a/pragma-node/src/handlers/stream/stream_single.rs
+++ b/pragma-node/src/handlers/stream/stream_single.rs
@@ -110,7 +110,7 @@ pub async fn stream_entry(
                             }
                         } else {
                             // For subsequent updates, get latest price
-                            match get_latest_entry(&state, &pair, is_routing, &params).await {
+                            match get_latest_entry(&state, &pair, is_routing, &params, false).await {
                                 Ok(entry_response) => Event::default()
                                     .json_data(&entry_response)
                                     .unwrap_or_else(|e| {

--- a/pragma-node/src/infra/repositories/entry_repository.rs
+++ b/pragma-node/src/infra/repositories/entry_repository.rs
@@ -276,7 +276,7 @@ pub async fn get_twap_price_with_components(
             bucket AS time,
             price_twap AS median_price,
             num_sources,
-            COALESCE(components, ARRAY[]::record(text,text,numeric,timestamptz)[]) as components,
+            components,
             (components IS NOT NULL AND array_length(components, 1) > 0) as has_components
         FROM
             twap_{}_agg{}
@@ -401,15 +401,13 @@ pub async fn get_median_price_with_components(
     entry_params: &EntryParams,
 ) -> Result<MedianEntry, InfraError> {
     let conn = pool.get().await.map_err(InfraError::DbPoolError)?;
-
-    // Get components and check existence in a single query
     let sql_request: String = format!(
         r"
         SELECT
             bucket AS time,
             median_price,
             num_sources,
-            COALESCE(components, ARRAY[]::record(text,text,numeric,timestamptz)[]) as components,
+            components,
             (components IS NOT NULL AND array_length(components, 1) > 0) as has_components
         FROM
             price_{}_agg{}

--- a/pragma-node/src/infra/repositories/entry_repository.rs
+++ b/pragma-node/src/infra/repositories/entry_repository.rs
@@ -563,7 +563,7 @@ pub async fn get_median_prices_between(
             bucket AS time,
             median_price,
             num_sources, 
-            COALESCE(components, ARRAY[]::record(text,text,numeric,timestamptz)[]) as components,
+            components,
             (components IS NOT NULL AND array_length(components, 1) > 0) as has_components
         FROM
             price_{}_agg{}

--- a/pragma-node/src/infra/repositories/entry_repository.rs
+++ b/pragma-node/src/infra/repositories/entry_repository.rs
@@ -127,7 +127,7 @@ pub fn calculate_rebased_price(
         time: new_timestamp,
         median_price: rebase_price,
         num_sources,
-        components: Option::None, // No components for routing
+        components: Option::None,
     };
 
     Ok(median_entry)
@@ -261,7 +261,7 @@ pub async fn get_twap_price_without_components(
     })
 }
 
-// Function to get TWAP price with components - optimized to avoid extra check
+// Function to get TWAP price with components
 pub async fn get_twap_price_with_components(
     pool: &deadpool_diesel::postgres::Pool,
     pair_id: String,
@@ -269,7 +269,6 @@ pub async fn get_twap_price_with_components(
 ) -> Result<MedianEntry, InfraError> {
     let conn = pool.get().await.map_err(InfraError::DbPoolError)?;
 
-    // Get components and check existence in a single query
     let sql_request: String = format!(
         r"
         SELECT
@@ -394,7 +393,7 @@ pub async fn get_median_price_without_components(
     })
 }
 
-// Function to get median price with components - optimized to avoid extra check
+// Function to get median price with components
 pub async fn get_median_price_with_components(
     pool: &deadpool_diesel::postgres::Pool,
     pair_id: String,
@@ -1139,7 +1138,7 @@ pub async fn get_expiries_list(
     Ok(expiries)
 }
 
-// Add a new struct to hold the individual price data
+// struct to hold the individual price data
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Component {
     pub source: String,
@@ -1148,7 +1147,6 @@ pub struct Component {
     pub timestamp: NaiveDateTime,
 }
 
-// Add implementation of From for converting between Component and EntryComponent
 impl From<Component> for crate::handlers::get_entry::EntryComponent {
     fn from(individual: Component) -> Self {
         Self {
@@ -1160,7 +1158,7 @@ impl From<Component> for crate::handlers::get_entry::EntryComponent {
     }
 }
 
-// Add reverse conversion
+// Reverse conversion
 impl TryFrom<crate::handlers::get_entry::EntryComponent> for Component {
     type Error = InfraError;
 

--- a/pragma-node/src/utils/mod.rs
+++ b/pragma-node/src/utils/mod.rs
@@ -251,7 +251,7 @@ mod tests {
                 .naive_utc(),
             median_price: median_price.into(),
             num_sources: 5,
-            components: Option::None
+            components: Option::None,
         }
     }
 

--- a/pragma-node/src/utils/mod.rs
+++ b/pragma-node/src/utils/mod.rs
@@ -251,6 +251,7 @@ mod tests {
                 .naive_utc(),
             median_price: median_price.into(),
             num_sources: 5,
+            components: Option::None
         }
     }
 


### PR DESCRIPTION
Resolves #187 

## Addition

- Added individual prices aggregation to the SQL migration for continuous aggregates.
- Introduced `DetailedMedianEntry` and `IndividualPrice` structs to hold detailed price data.
- Updated entry handling in the repository and response structures to accommodate new data.
- Refactored `get_entry` response to include components for individual prices.

## TODO: 

- [x]  Make sure no breaking changes
- [x] Check if we want to load individual prices for historical data too
- [x] Check what should we load for the computed rebase (base components, quote components, none of them ?)
- [x] Tests