### PR TITLE
feat: funding rates table ingested from kafka

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1788,7 +1788,7 @@ source = "sparse+https://registry.devnet.pragma.build/api/v1/crates/"
 checksum = "88ec94858b4e5d0ad02004347796ff3ed17817a2b6dc6c7adb3c60c67159676d"
 dependencies = [
  "pragma-common",
- "rdkafka 0.37.0",
+ "rdkafka",
  "thiserror 2.0.12",
 ]
 
@@ -3717,6 +3717,7 @@ name = "pragma-ingestor"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "clap",
  "deadpool-diesel",
  "dotenvy",
  "envy",
@@ -3725,7 +3726,7 @@ dependencies = [
  "lazy_static",
  "pragma-common",
  "pragma-entities",
- "rdkafka 0.36.2",
+ "rdkafka",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -3803,7 +3804,7 @@ dependencies = [
  "pragma-entities",
  "pragma-monitoring",
  "ratatui",
- "rdkafka 0.36.2",
+ "rdkafka",
  "rstest",
  "serde",
  "serde_json",
@@ -4153,24 +4154,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "529468c1335c1c03919960dfefdb1b3648858c20d7ec2d0663e728e4a717efbc"
 dependencies = [
  "bitflags 2.8.0",
-]
-
-[[package]]
-name = "rdkafka"
-version = "0.36.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1beea247b9a7600a81d4cc33f659ce1a77e1988323d7d2809c7ed1c21f4c316d"
-dependencies = [
- "futures-channel",
- "futures-util",
- "libc",
- "log",
- "rdkafka-sys",
- "serde",
- "serde_derive",
- "serde_json",
- "slab",
- "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,8 +98,9 @@ nonzero_ext = { version = "0.3.0" }
 serde_json = { version = "1.0.122", features = ["arbitrary_precision"] }
 starknet = "0.14.0"
 starknet-crypto = "0.7.4"
+clap = { version = "4.4", features = ["derive", "env"] }
 reqwest = { version = "0.12.5", features = ["blocking"] }
-rdkafka = "0.36.2"
+rdkafka = "0.37.0"
 thiserror = "2.0.12"
 strum = { version = "0.26", features = ["derive"] }
 url = "2.5.0"

--- a/pragma-entities/migrations/2025-04-20-145559_create-funding-rates-table/down.sql
+++ b/pragma-entities/migrations/2025-04-20-145559_create-funding-rates-table/down.sql
@@ -1,0 +1,10 @@
+-- This file should undo anything in `up.sql`
+
+-- Remove compression policy first
+SELECT remove_compression_policy('funding_rates');
+
+-- Disable compression
+ALTER TABLE funding_rates SET (timescaledb.compress = false);
+
+-- Drop the hypertable
+DROP TABLE funding_rates CASCADE;

--- a/pragma-entities/migrations/2025-04-20-145559_create-funding-rates-table/up.sql
+++ b/pragma-entities/migrations/2025-04-20-145559_create-funding-rates-table/up.sql
@@ -1,17 +1,17 @@
 -- Your SQL goes here
 
 CREATE TABLE funding_rates (
-    id SERIAL,
+    id uuid DEFAULT uuid_generate_v4(),
     source VARCHAR NOT NULL,
     pair VARCHAR NOT NULL,
     annualized_rate DOUBLE PRECISION NOT NULL,
-    timestamp_ms BIGINT NOT NULL,
-    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
-    UNIQUE(source, pair, timestamp_ms)
+    timestamp TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (id, timestamp)
 );
 
 -- Convert the table to a hypertable
-SELECT create_hypertable('funding_rates', 'timestamp_ms', chunk_time_interval => INTERVAL '1 day');
+SELECT create_hypertable('funding_rates', 'timestamp', chunk_time_interval => INTERVAL '1 day');
 
 -- Create an index for efficient querying by pair
 CREATE INDEX idx_funding_rates_pair ON funding_rates(pair);

--- a/pragma-entities/migrations/2025-04-20-145559_create-funding-rates-table/up.sql
+++ b/pragma-entities/migrations/2025-04-20-145559_create-funding-rates-table/up.sql
@@ -1,0 +1,26 @@
+-- Your SQL goes here
+
+CREATE TABLE funding_rates (
+    id SERIAL,
+    source VARCHAR NOT NULL,
+    pair VARCHAR NOT NULL,
+    annualized_rate DOUBLE PRECISION NOT NULL,
+    timestamp_ms BIGINT NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(source, pair, timestamp_ms)
+);
+
+-- Convert the table to a hypertable
+SELECT create_hypertable('funding_rates', 'timestamp_ms', chunk_time_interval => INTERVAL '1 day');
+
+-- Create an index for efficient querying by pair
+CREATE INDEX idx_funding_rates_pair ON funding_rates(pair);
+
+-- Enable compression
+ALTER TABLE funding_rates SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'source,pair'
+);
+
+-- Add compression policy to compress chunks older than 7 days
+SELECT add_compression_policy('funding_rates', INTERVAL '7 days');

--- a/pragma-entities/src/dto/future_entry.rs
+++ b/pragma-entities/src/dto/future_entry.rs
@@ -27,7 +27,7 @@ impl From<crate::FutureEntry> for FutureEntry {
             source: future_entry.source,
             timestamp: future_entry.timestamp.and_utc().timestamp_millis() as u64,
             expiration_timestamp,
-            publisher_signature: future_entry.publisher_signature,
+            publisher_signature: future_entry.publisher_signature.unwrap_or_default(),
             price: future_entry.price.to_u128().unwrap_or(0), // change default value ?
         }
     }

--- a/pragma-entities/src/lib.rs
+++ b/pragma-entities/src/lib.rs
@@ -15,6 +15,7 @@ pub use error::InfraError;
 pub use models::{
     checkpoint_error::CheckpointError,
     entry::{Entry, NewEntry},
+    funding_rate::{FundingRate, NewFundingRate},
     future_entry::{FutureEntry, NewFutureEntry},
     publisher::{NewPublisher, Publishers},
     publisher_error::PublisherError,

--- a/pragma-entities/src/models/entries/future_entry.rs
+++ b/pragma-entities/src/models/entries/future_entry.rs
@@ -25,7 +25,7 @@ pub struct FutureEntry {
     // If expiration_timestamp is None, it means the entry is a perpetual future
     // else it is a regular future entry that will expire at the expiration_timestamp.
     pub expiration_timestamp: Option<NaiveDateTime>,
-    pub publisher_signature: String,
+    pub publisher_signature: Option<String>,
     pub price: BigDecimal,
 }
 

--- a/pragma-entities/src/models/funding_rate.rs
+++ b/pragma-entities/src/models/funding_rate.rs
@@ -1,0 +1,38 @@
+use chrono::NaiveDateTime;
+use diesel::prelude::*;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::schema::funding_rates;
+
+#[derive(Debug, Clone, Queryable, Serialize, Deserialize)]
+#[diesel(table_name = funding_rates)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct FundingRate {
+    pub id: Uuid,
+    pub source: String,
+    pub pair: String,
+    pub annualized_rate: f64,
+    pub timestamp: NaiveDateTime,
+    pub created_at: NaiveDateTime,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Insertable, AsChangeset)]
+#[diesel(table_name = funding_rates)]
+pub struct NewFundingRate {
+    pub source: String,
+    pub pair: String,
+    pub annualized_rate: f64,
+    pub timestamp: NaiveDateTime,
+}
+
+impl FundingRate {
+    pub fn create_many(
+        conn: &mut PgConnection,
+        new_entries: Vec<NewFundingRate>,
+    ) -> Result<Vec<Self>, diesel::result::Error> {
+        diesel::insert_into(funding_rates::table)
+            .values(&new_entries)
+            .get_results(conn)
+    }
+}

--- a/pragma-entities/src/models/mod.rs
+++ b/pragma-entities/src/models/mod.rs
@@ -1,5 +1,6 @@
 pub mod checkpoint_error;
 pub mod entries;
+pub mod funding_rate;
 pub mod publisher;
 pub mod publisher_error;
 

--- a/pragma-entities/src/schema.rs
+++ b/pragma-entities/src/schema.rs
@@ -4,11 +4,22 @@ diesel::table! {
     entries (id, timestamp) {
         id -> Uuid,
         pair_id -> Varchar,
-        publisher -> Text,
-        timestamp -> Timestamptz,
         price -> Numeric,
+        timestamp -> Timestamptz,
+        publisher -> Text,
+        publisher_signature -> Nullable<Text>,
         source -> Varchar,
-        publisher_signature -> Nullable<Varchar>,
+    }
+}
+
+diesel::table! {
+    funding_rates (id, timestamp) {
+        id -> Uuid,
+        source -> Varchar,
+        pair -> Varchar,
+        annualized_rate -> Float8,
+        timestamp -> Timestamptz,
+        created_at -> Timestamptz,
     }
 }
 
@@ -20,7 +31,7 @@ diesel::table! {
         timestamp -> Timestamptz,
         expiration_timestamp -> Nullable<Timestamptz>,
         publisher -> Text,
-        publisher_signature -> Text,
+        publisher_signature -> Nullable<Text>,
         source -> Varchar,
     }
 }
@@ -31,9 +42,9 @@ diesel::table! {
         name -> Varchar,
         master_key -> Varchar,
         active_key -> Varchar,
-        active -> Bool,
         account_address -> Varchar,
+        active -> Bool,
     }
 }
 
-diesel::allow_tables_to_appear_in_same_query!(entries, future_entries, publishers,);
+diesel::allow_tables_to_appear_in_same_query!(entries, funding_rates, future_entries, publishers,);

--- a/pragma-ingestor/Cargo.toml
+++ b/pragma-ingestor/Cargo.toml
@@ -23,3 +23,4 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tracing = { workspace = true }
+clap = { workspace = true, features = ["derive"] }

--- a/pragma-ingestor/src/config.rs
+++ b/pragma-ingestor/src/config.rs
@@ -1,21 +1,16 @@
-use serde::{Deserialize, Serialize};
+use clap::Parser;
 use std::sync::LazyLock;
 
-use crate::error::PragmaConsumerError;
+pub(crate) static CONFIG: LazyLock<Ingestor> = LazyLock::new(load_configuration);
 
-pub static CONFIG: LazyLock<Ingestor> = LazyLock::new(load_configuration);
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct Ingestor {
-    pub num_consumers: usize,
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+pub(crate) struct Ingestor {
+    /// Number of consumers to run
+    #[arg(long, env = "NUM_CONSUMERS", default_value = "10")]
+    pub(crate) num_consumers: usize,
 }
 
-impl Ingestor {
-    pub fn from_env() -> Result<Self, PragmaConsumerError> {
-        envy::from_env::<Self>().map_err(PragmaConsumerError::LoadConfig)
-    }
-}
-
-pub fn load_configuration() -> Ingestor {
-    Ingestor::from_env().expect("cannot load configuration env")
+pub(crate) fn load_configuration() -> Ingestor {
+    Ingestor::parse()
 }

--- a/pragma-ingestor/src/db.rs
+++ b/pragma-ingestor/src/db.rs
@@ -1,0 +1,147 @@
+use deadpool_diesel::postgres::Pool;
+use pragma_entities::{Entry, FutureEntry, InfraError, NewEntry, NewFutureEntry};
+use tokio::sync::mpsc;
+use tokio::time::{Duration, interval};
+use tracing::debug;
+
+#[tracing::instrument(skip(pool, rx))]
+pub async fn process_spot_entries(pool: Pool, mut rx: mpsc::Receiver<NewEntry>) {
+    const BUFFER_CAPACITY: usize = 100;
+    const FLUSH_TIMEOUT: Duration = Duration::from_millis(50);
+
+    let mut buffer = Vec::with_capacity(BUFFER_CAPACITY);
+    let mut flush_interval = interval(FLUSH_TIMEOUT);
+
+    loop {
+        tokio::select! {
+            Some(entry) = rx.recv() => {
+                buffer.push(entry);
+
+                if buffer.len() >= BUFFER_CAPACITY {
+                    if let Err(e) = insert_spot_entries(&pool, std::mem::take(&mut buffer)).await {
+                        tracing::error!("❌ Failed to insert spot entries: {}", e);
+                    }
+                    buffer = Vec::with_capacity(BUFFER_CAPACITY);
+                }
+            }
+            _ = flush_interval.tick() => {
+                if !buffer.is_empty() {
+                    if let Err(e) = insert_spot_entries(&pool, std::mem::take(&mut buffer)).await {
+                        tracing::error!("❌ Failed to flush spot entries: {}", e);
+                    }
+                    buffer = Vec::with_capacity(BUFFER_CAPACITY);
+                }
+            }
+            else => {
+                // Channel closed, flush remaining entries
+                if !buffer.is_empty() {
+                    if let Err(e) = insert_spot_entries(&pool, buffer).await {
+                        tracing::error!("❌ Failed to flush final spot entries: {}", e);
+                    }
+                }
+                break;
+            }
+        }
+    }
+}
+
+#[tracing::instrument(skip(pool, rx))]
+pub async fn process_future_entries(pool: Pool, mut rx: mpsc::Receiver<NewFutureEntry>) {
+    const BUFFER_CAPACITY: usize = 100;
+    const FLUSH_TIMEOUT: Duration = Duration::from_secs(30);
+
+    let mut buffer = Vec::with_capacity(BUFFER_CAPACITY);
+    let mut flush_interval = interval(FLUSH_TIMEOUT);
+
+    loop {
+        tokio::select! {
+            Some(entry) = rx.recv() => {
+                buffer.push(entry);
+
+                if buffer.len() >= BUFFER_CAPACITY {
+                    if let Err(e) = insert_future_entries(&pool, std::mem::take(&mut buffer)).await {
+                        tracing::error!("❌ Failed to insert future entries: {}", e);
+                    }
+                    buffer = Vec::with_capacity(BUFFER_CAPACITY);
+                }
+            }
+            _ = flush_interval.tick() => {
+                if !buffer.is_empty() {
+                    if let Err(e) = insert_future_entries(&pool, std::mem::take(&mut buffer)).await {
+                        tracing::error!("❌ Failed to flush future entries: {}", e);
+                    }
+                    buffer = Vec::with_capacity(BUFFER_CAPACITY);
+                }
+            }
+            else => {
+                // Channel closed, flush remaining entries
+                if !buffer.is_empty() {
+                    if let Err(e) = insert_future_entries(&pool, buffer).await {
+                        tracing::error!("❌ Failed to flush final future entries: {}", e);
+                    }
+                }
+                break;
+            }
+        }
+    }
+}
+
+#[tracing::instrument(skip(pool))]
+async fn insert_spot_entries(pool: &Pool, new_entries: Vec<NewEntry>) -> Result<(), InfraError> {
+    let conn = pool.get().await.map_err(InfraError::DbPoolError)?;
+    let entries = conn
+        .interact(move |conn| Entry::create_many(conn, new_entries))
+        .await
+        .map_err(InfraError::DbInteractionError)?
+        .map_err(InfraError::DbResultError)?;
+
+    for entry in &entries {
+        debug!(
+            "new spot entry created {} - {}({}) - {}",
+            entry.publisher, entry.pair_id, entry.price, entry.source
+        );
+    }
+
+    Ok(())
+}
+
+#[tracing::instrument(skip(pool))]
+async fn insert_future_entries(
+    pool: &Pool,
+    new_entries: Vec<NewFutureEntry>,
+) -> Result<(), InfraError> {
+    let conn = pool.get().await.map_err(InfraError::DbPoolError)?;
+
+    let new_entries = new_entries
+        .into_iter()
+        .map(|mut entry| {
+            if let Some(expiration_timestamp) = entry.expiration_timestamp {
+                if expiration_timestamp.and_utc().timestamp() == 0 {
+                    entry.expiration_timestamp = None;
+                }
+            }
+            entry
+        })
+        .collect::<Vec<_>>();
+
+    debug!(
+        "[PERP] {} new entries available",
+        new_entries
+            .iter()
+            .filter(|entry| entry.expiration_timestamp.is_none())
+            .count()
+    );
+
+    let entries = conn
+        .interact(move |conn| FutureEntry::create_many(conn, new_entries))
+        .await
+        .map_err(InfraError::DbInteractionError)?
+        .map_err(InfraError::DbResultError)?;
+    for entry in &entries {
+        debug!(
+            "new perp entry created {} - {}({}) - {}",
+            entry.publisher, entry.pair_id, entry.price, entry.source
+        );
+    }
+    Ok(())
+}

--- a/pragma-ingestor/src/error.rs
+++ b/pragma-ingestor/src/error.rs
@@ -1,7 +1,7 @@
 use thiserror::Error;
 
 #[derive(Error, Debug)]
-pub enum PragmaConsumerError {
+pub(crate) enum PragmaConsumerError {
     #[error("read config error: {0}")]
     ReadConfig(#[from] std::io::Error),
     #[error("load config error: {0}")]

--- a/pragma-ingestor/src/main.rs
+++ b/pragma-ingestor/src/main.rs
@@ -1,19 +1,23 @@
 use dotenvy::{dotenv, var};
 use futures_util::stream::{FuturesUnordered, StreamExt};
 use rdkafka::Message as _;
-use rdkafka::message::OwnedMessage;
 use tokio::sync::mpsc;
+use tokio::task::JoinSet;
 use tracing::{error, info};
 
 use faucon_rs::config::{FauConfig, FauconEnvironment};
 use faucon_rs::consumer::FauConsumer;
 use faucon_rs::topics::FauconTopic;
-use pragma_common::{CapnpDeserialize, InstrumentType, entries::PriceEntry, task_group::TaskGroup};
+use pragma_common::{
+    CapnpDeserialize, InstrumentType,
+    entries::{FundingRateEntry, PriceEntry},
+    task_group::TaskGroup,
+};
 use pragma_entities::connection::ENV_OFFCHAIN_DATABASE_URL;
-use pragma_entities::{NewEntry, NewFutureEntry};
+use pragma_entities::{NewEntry, NewFundingRate, NewFutureEntry};
 
 use crate::config::CONFIG;
-use crate::db::{process_future_entries, process_spot_entries};
+use crate::db::{process_funding_rate_entries, process_future_entries, process_spot_entries};
 
 mod config;
 mod db;
@@ -39,55 +43,114 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let pool = pragma_entities::connection::init_pool("pragma-ingestor", ENV_OFFCHAIN_DATABASE_URL)
         .expect("Failed to connect to offchain database");
 
-    // Set up channels for spot and future entries with backpressure
+    // Set up channels for spot, future, and funding rate entries with backpressure
     let (spot_tx, spot_rx) = mpsc::channel::<NewEntry>(CHANNEL_CAPACITY);
     let (future_tx, future_rx) = mpsc::channel::<NewFutureEntry>(CHANNEL_CAPACITY);
+    let (funding_rate_tx, funding_rate_rx) = mpsc::channel::<NewFundingRate>(CHANNEL_CAPACITY);
 
     // Spawn database worker tasks
     let task_group = TaskGroup::new()
         .with_handle(tokio::spawn(process_spot_entries(pool.clone(), spot_rx)))
-        .with_handle(tokio::spawn(process_future_entries(pool, future_rx)));
+        .with_handle(tokio::spawn(process_future_entries(
+            pool.clone(),
+            future_rx,
+        )))
+        .with_handle(tokio::spawn(process_funding_rate_entries(
+            pool,
+            funding_rate_rx,
+        )));
 
-    (0..CONFIG.num_consumers)
-        .map(|_| {
-            tokio::spawn(run_consumer(
-                config.clone(),
-                KAFKA_GROUP_ID.to_string(),
-                spot_tx.clone(),
-                future_tx.clone(),
-            ))
-        })
-        .collect::<FuturesUnordered<_>>()
-        .for_each(|_| async { () })
-        .await;
+    // Spawn price consumers
+    let mut join_set = JoinSet::new();
+    for _ in 0..CONFIG.num_consumers {
+        join_set.spawn(run_price_consumer(
+            config.clone(),
+            KAFKA_GROUP_ID.to_string(),
+            spot_tx.clone(),
+            future_tx.clone(),
+        ));
+        join_set.spawn(run_funding_rate_consumer(
+            config.clone(),
+            KAFKA_GROUP_ID.to_string(),
+            funding_rate_tx.clone(),
+        ));
+    }
+
+    while let Some(result) = join_set.join_next().await {
+        if let Err(e) = result {
+            error!("Consumer error: {}", e);
+        }
+    }
 
     // Drop original senders to close channels when consumers finish
     drop(spot_tx);
     drop(future_tx);
+    drop(funding_rate_tx);
 
     // Await all tasks and abort if one fails
     task_group.abort_all_if_one_resolves().await;
     Ok(())
 }
 
-/// Runs a single Kafka consumer, processing messages and sending entries to channels.
-async fn run_consumer(
+/// Runs a Kafka consumer for price entries
+async fn run_price_consumer(
     config: FauConfig,
     group_id: String,
     spot_tx: mpsc::Sender<NewEntry>,
     future_tx: mpsc::Sender<NewFutureEntry>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    // Initialize and subscribe Kafka consumer
     let mut consumer = FauConsumer::new(config, &group_id)?;
     consumer.subscribe(FauconTopic::PRICES_V1)?;
     let mut stream = consumer.stream();
 
-    // Process messages from the Kafka stream
+    tracing::info!("🚀 Starting price consumer");
+
     while let Some(msg_result) = stream.next().await {
         match msg_result {
             Ok(msg) => {
                 let owned_message = msg.detach();
-                process_message(&owned_message, &spot_tx, &future_tx).await;
+                if let Some(payload) = owned_message.payload() {
+                    match PriceEntry::from_capnp(payload) {
+                        Ok(entry) => {
+                            let timestamp =
+                                chrono::DateTime::from_timestamp_millis(entry.timestamp_ms)
+                                    .map(|dt| dt.naive_utc())
+                                    .unwrap_or_else(|| {
+                                        error!("Invalid timestamp: {}", entry.timestamp_ms);
+                                        chrono::NaiveDateTime::default()
+                                    });
+
+                            match entry.instrument_type() {
+                                InstrumentType::Spot => {
+                                    let spot_entry = NewEntry {
+                                        source: entry.source,
+                                        pair_id: entry.pair.to_string(),
+                                        publisher: PUBLISHER_NAME.to_string(),
+                                        price: entry.price.into(),
+                                        timestamp,
+                                    };
+                                    if let Err(e) = spot_tx.send(spot_entry).await {
+                                        error!("Failed to send spot entry: {}", e);
+                                    }
+                                }
+                                InstrumentType::Perp => {
+                                    let future_entry = NewFutureEntry {
+                                        pair_id: entry.pair.to_string(),
+                                        publisher: PUBLISHER_NAME.to_string(),
+                                        source: entry.source,
+                                        price: entry.price.into(),
+                                        timestamp,
+                                        expiration_timestamp: None,
+                                    };
+                                    if let Err(e) = future_tx.send(future_entry).await {
+                                        error!("Failed to send future entry: {}", e);
+                                    }
+                                }
+                            }
+                        }
+                        Err(e) => error!("Failed to deserialize price entry: {}", e),
+                    }
+                }
             }
             Err(e) => error!("Consumer error: {}", e),
         }
@@ -96,54 +159,49 @@ async fn run_consumer(
     Ok(())
 }
 
-/// Processes a single Kafka message and routes it to the appropriate channel.
-async fn process_message(
-    msg: &OwnedMessage,
-    spot_tx: &mpsc::Sender<NewEntry>,
-    future_tx: &mpsc::Sender<NewFutureEntry>,
-) {
-    if let Some(payload) = msg.payload() {
-        match PriceEntry::from_capnp(payload) {
-            Ok(entry) => {
-                // Convert timestamp to NaiveDateTime
-                let timestamp = chrono::DateTime::from_timestamp_millis(entry.timestamp_ms)
-                    .map(|dt| dt.naive_utc())
-                    .unwrap_or_else(|| {
-                        error!("Invalid timestamp: {}", entry.timestamp_ms);
-                        chrono::NaiveDateTime::default()
-                    });
+/// Runs a Kafka consumer for funding rate entries
+async fn run_funding_rate_consumer(
+    config: FauConfig,
+    group_id: String,
+    funding_rate_tx: mpsc::Sender<NewFundingRate>,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let mut consumer = FauConsumer::new(config, &group_id)?;
+    consumer.subscribe(FauconTopic::FUNDING_RATES_V1)?;
+    let mut stream = consumer.stream();
 
-                match entry.instrument_type() {
-                    InstrumentType::Spot => {
-                        let spot_entry = NewEntry {
-                            source: entry.source,
-                            pair_id: entry.pair.to_string(),
-                            publisher: PUBLISHER_NAME.to_string(),
-                            price: entry.price.into(),
-                            timestamp,
-                        };
-                        if let Err(e) = spot_tx.send(spot_entry).await {
-                            error!("Failed to send spot entry: {}", e);
+    tracing::info!("🚀 Starting funding rate consumer");
+
+    while let Some(msg_result) = stream.next().await {
+        match msg_result {
+            Ok(msg) => {
+                let owned_message = msg.detach();
+                if let Some(payload) = owned_message.payload() {
+                    match FundingRateEntry::from_capnp(payload) {
+                        Ok(entry) => {
+                            let funding_rate_entry = NewFundingRate {
+                                source: entry.source,
+                                pair: entry.pair.to_string(),
+                                annualized_rate: entry.annualized_rate,
+                                timestamp: chrono::DateTime::from_timestamp_millis(
+                                    entry.timestamp_ms,
+                                )
+                                .map(|dt| dt.naive_utc())
+                                .unwrap_or_else(|| {
+                                    error!("Invalid timestamp: {}", entry.timestamp_ms);
+                                    chrono::NaiveDateTime::default()
+                                }),
+                            };
+                            if let Err(e) = funding_rate_tx.send(funding_rate_entry).await {
+                                error!("Failed to send funding rate entry: {}", e);
+                            }
                         }
-                    }
-                    InstrumentType::Perp => {
-                        let future_entry = NewFutureEntry {
-                            pair_id: entry.pair.to_string(),
-                            publisher: PUBLISHER_NAME.to_string(),
-                            source: entry.source,
-                            price: entry.price.into(),
-                            timestamp,
-                            expiration_timestamp: None,
-                        };
-                        if let Err(e) = future_tx.send(future_entry).await {
-                            error!("Failed to send future entry: {}", e);
-                        }
+                        Err(e) => error!("Failed to deserialize funding rate entry: {}", e),
                     }
                 }
             }
-            Err(e) => error!("Failed to deserialize price entry: {}", e),
+            Err(e) => error!("Consumer error: {}", e),
         }
-    } else {
-        error!("Received message with no payload");
     }
+
+    Ok(())
 }


### PR DESCRIPTION
## Changes
- Creates a new table `funding_rates`
- Update `pragma-ingestor` to fill this table with entries from kafka

## Current design

We spawn `NUM_CONSUMERS` consumers for each topic.
Each consumer sends data through a bounded `mpsc` channel.
Other tasks process these data points with a buffer system i.e we insert in db by batch.