### PR TITLE
feat: add rustls dependency with crypto provider initialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4039,6 +4039,7 @@ dependencies = [
  "pragma-entities",
  "rdkafka",
  "reqwest 0.12.23",
+ "rustls 0.23.31",
  "serde",
  "serde_json",
  "thiserror 2.0.16",
@@ -4065,6 +4066,7 @@ dependencies = [
  "pragma-common",
  "pragma-entities",
  "rdkafka",
+ "rustls 0.23.31",
  "serde",
  "serde_json",
  "strum 0.26.3",
@@ -4163,6 +4165,7 @@ dependencies = [
  "ratatui",
  "rdkafka",
  "rstest",
+ "rustls 0.23.31",
  "serde",
  "serde_json",
  "starknet",
@@ -4957,6 +4960,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",

--- a/pragma-historical/Cargo.toml
+++ b/pragma-historical/Cargo.toml
@@ -28,3 +28,4 @@ thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tracing = { workspace = true }
 uuid = { workspace = true }
+rustls = { version = "0.23", features = ["ring"] }

--- a/pragma-historical/src/main.rs
+++ b/pragma-historical/src/main.rs
@@ -98,6 +98,11 @@ struct Cli {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    // Initialize the default crypto provider for rustls before any TLS operations
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .expect("Failed to install default crypto provider");
+    
     check_timescaledb_parallel_copy()?;
 
     let cli = Cli::parse();

--- a/pragma-ingestor/Cargo.toml
+++ b/pragma-ingestor/Cargo.toml
@@ -28,3 +28,4 @@ strum = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tracing = { workspace = true }
+rustls = { version = "0.23", features = ["ring"] }

--- a/pragma-ingestor/src/main.rs
+++ b/pragma-ingestor/src/main.rs
@@ -30,6 +30,11 @@ mod metrics;
 #[tokio::main]
 #[tracing::instrument]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Initialize the default crypto provider for rustls before any TLS operations
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .expect("Failed to install default crypto provider");
+    
     dotenv().ok();
 
     // We export our telemetry - so we can monitor the ingestor through Grafana.

--- a/pragma-node/Cargo.toml
+++ b/pragma-node/Cargo.toml
@@ -54,6 +54,7 @@ utoipa = { workspace = true }
 utoipa-swagger-ui = { workspace = true }
 utoipauto = { workspace = true }
 uuid = { workspace = true, features = ["fast-rng", "v4", "serde"] }
+rustls = { version = "0.23", features = ["ring"] }
 
 [dev-dependencies]
 rstest = { workspace = true }

--- a/pragma-node/src/main.rs
+++ b/pragma-node/src/main.rs
@@ -14,6 +14,10 @@ use pragma_node::state::AppState;
 #[tokio::main]
 #[tracing::instrument]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Initialize the default crypto provider for rustls before any TLS operations
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .expect("Failed to install default crypto provider");
     dotenv().ok();
 
     let otel_endpoint = std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT").ok();


### PR DESCRIPTION
- Added rustls version 0.23.31 to Cargo.toml files across multiple projects.
- Implemented default crypto provider initialization for rustls in main.rs files of ingestor, historical, and node modules.